### PR TITLE
Rename "ferric-modules" to "ferric-cli"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5814,12 +5814,12 @@
         "bser": "2.1.1"
       }
     },
-    "node_modules/ferric-example": {
-      "resolved": "packages/ferric-example",
+    "node_modules/ferric-cli": {
+      "resolved": "packages/ferric",
       "link": true
     },
-    "node_modules/ferric-modules": {
-      "resolved": "packages/ferric",
+    "node_modules/ferric-example": {
+      "resolved": "packages/ferric-example",
       "link": true
     },
     "node_modules/file-entry-cache": {
@@ -9881,7 +9881,7 @@
       }
     },
     "packages/ferric": {
-      "name": "ferric-modules",
+      "name": "ferric-cli",
       "version": "0.1.0",
       "dependencies": {
         "@commander-js/extra-typings": "^13.1.0",
@@ -9898,7 +9898,7 @@
     "packages/ferric-example": {
       "version": "0.1.0",
       "devDependencies": {
-        "ferric-modules": "^0.1.0"
+        "ferric-cli": "^0.1.0"
       }
     },
     "packages/ferric/node_modules/@commander-js/extra-typings": {

--- a/packages/ferric-example/package.json
+++ b/packages/ferric-example/package.json
@@ -14,6 +14,6 @@
     "build": "ferric build --android --apple"
   },
   "devDependencies": {
-    "ferric-modules": "^0.1.0"
+    "ferric-cli": "^0.1.0"
   }
 }

--- a/packages/ferric/package.json
+++ b/packages/ferric/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ferric-modules",
+  "name": "ferric-cli",
   "version": "0.1.0",
   "description": "Rust Node-API Modules for React Native",
   "homepage": "https://github.com/callstackincubator/react-native-node-api-modules",


### PR DESCRIPTION
It turns out this was more a CLI wrapping the other tools - giving it a "-modules" suffix feels a bit like a stretch as it's not really a module system the same way react-native-node-api-modules is.