### PR TITLE
Build for simulators by default

### DIFF
--- a/packages/cmake-rn/src/android.ts
+++ b/packages/cmake-rn/src/android.ts
@@ -94,3 +94,8 @@ export function getAndroidConfigureCmakeArgs({
       .join(" ")}`,
   ];
 }
+
+export function isAndroidSupported() {
+  const { ANDROID_HOME } = process.env;
+  return typeof ANDROID_HOME === "string" && fs.existsSync(ANDROID_HOME);
+}

--- a/packages/cmake-rn/src/apple.ts
+++ b/packages/cmake-rn/src/apple.ts
@@ -107,3 +107,7 @@ export function getAppleBuildArgs() {
   // We expect the final application to sign these binaries
   return ["CODE_SIGNING_ALLOWED=NO"];
 }
+
+export function isAppleSupported() {
+  return process.platform === "darwin";
+}

--- a/packages/cmake-rn/src/cli.ts
+++ b/packages/cmake-rn/src/cli.ts
@@ -10,11 +10,13 @@ import chalk from "chalk";
 
 import {
   DEFAULT_APPLE_TRIPLETS,
+  isAppleSupported,
   getAppleBuildArgs,
   getAppleConfigureCmakeArgs,
 } from "./apple.js";
 import {
   DEFAULT_ANDROID_TRIPLETS,
+  isAndroidSupported,
   getAndroidConfigureCmakeArgs,
 } from "./android.js";
 import { getWeakNodeApiVariables } from "./weak-node-api.js";
@@ -129,19 +131,23 @@ export const program = new Command("cmake-rn")
       }
 
       if (triplets.size === 0) {
-        console.error(
-          "Nothing to build 🤷",
-          "Please specify at least one triplet with",
-          chalk.dim("--triplet"),
-          `(or use the ${chalk.dim("--android")} or ${chalk.dim(
-            "--apple"
-          )} shorthands)`
-        );
-        for (const triplet of SUPPORTED_TRIPLETS) {
-          console.error(`${chalk.dim("--triplet")} ${triplet}`);
+        if (isAndroidSupported()) {
+          if (process.arch === "arm64") {
+            triplets.add("aarch64-linux-android");
+          } else if (process.arch === "x64") {
+            triplets.add("x86_64-linux-android");
+          }
         }
-        process.exitCode = 1;
-        return;
+        if (isAppleSupported()) {
+          if (process.arch === "arm64") {
+            triplets.add("arm64-apple-ios-sim");
+          }
+        }
+        console.error(
+          chalk.yellowBright("ℹ"),
+          "Using default triplets",
+          chalk.dim("(" + [...triplets].join(", ") + ")")
+        );
       }
 
       const tripletContext = [...triplets].map((triplet) => {

--- a/packages/ferric/src/build.ts
+++ b/packages/ferric/src/build.ts
@@ -118,6 +118,31 @@ export const buildCommand = new Command("build")
             targets.add(target);
           }
         }
+
+        if (targets.size === 0) {
+          if (isAndroidSupported()) {
+            if (process.arch === "arm64") {
+              targets.add("aarch64-linux-android");
+            } else if (process.arch === "x64") {
+              targets.add("x86_64-linux-android");
+            }
+          }
+          if (isAppleSupported()) {
+            if (process.arch === "arm64") {
+              targets.add("aarch64-apple-ios-sim");
+            }
+          }
+          console.error(
+            chalk.yellowBright("ℹ"),
+            chalk.dim(
+              `Using default targets, pass ${chalk.italic(
+                "--android"
+              )}, ${chalk.italic("--apple")} or individual ${chalk.italic(
+                "--target"
+              )} options, to avoid this.`
+            )
+          );
+        }
         ensureCargo();
         ensureInstalledTargets(targets);
 
@@ -313,4 +338,13 @@ async function combineLibraries(
     );
     return [...result, universalPath];
   }
+}
+
+export function isAndroidSupported() {
+  const { ANDROID_HOME } = process.env;
+  return typeof ANDROID_HOME === "string" && fs.existsSync(ANDROID_HOME);
+}
+
+export function isAppleSupported() {
+  return process.platform === "darwin";
 }


### PR DESCRIPTION
Merging this PR will:
- Introduce a default behavior for both `cmake-rn` and `ferric` to build for targets / triplets needed for iOS simulator and Android emulator.