### PR TITLE
Fix: Escape package name (#127)

### DIFF
--- a/packages/host/src/node/path-utils.ts
+++ b/packages/host/src/node/path-utils.ts
@@ -148,9 +148,10 @@ export function escapePath(modulePath: string) {
  */
 export function getLibraryName(modulePath: string, naming: NamingStrategy) {
   const { packageName, relativePath } = determineModuleContext(modulePath);
+  const escapedPackageName = escapePath(packageName);
   return naming.stripPathSuffix
-    ? packageName
-    : `${packageName}--${escapePath(relativePath)}`;
+    ? escapedPackageName
+    : `${escapedPackageName}--${escapePath(relativePath)}`;
 }
 
 export function prettyPath(p: string) {


### PR DESCRIPTION
This change fixes [#127](https://github.com/callstackincubator/react-native-node-api/issues/127) by simply escaping (i.e. replacing) all non-alphanumeric characters with `-` (including `-` itself). While the `escapePath()` is overly strict (e.g. does not allow a valid `_` character) it does not need relaxing for now.

Lifting limitations is always backwards-compatible; introducing them is not.