### PR TITLE
Set non-zero exit code on errors

### DIFF
--- a/packages/ferric/src/build.ts
+++ b/packages/ferric/src/build.ts
@@ -287,6 +287,7 @@ export const buildCommand = new Command("build")
           }
         );
       } catch (error) {
+        process.exitCode = 1;
         if (error instanceof SpawnFailure) {
           error.flushOutput("both");
         }


### PR DESCRIPTION
Merging this PR will:
- Ensure the Ferric build tool fails with a non-zero exit code on usage and spawn errors.