### PR TITLE
Add `--out-to-build` option

### DIFF
--- a/packages/cmake-rn/src/cli.ts
+++ b/packages/cmake-rn/src/cli.ts
@@ -79,9 +79,14 @@ const cleanOption = new Option(
   "Delete the build directory before configuring the project"
 );
 
-const outPathOption = new Option(
+const outOption = new Option(
   "--out <path>",
   "Specify the output directory to store the final build artifacts"
+);
+
+const outToBuildOption = new Option(
+  "--out-to-build",
+  "Use `./build/${configuration}` directory as output (like `node-gyp` and `cmake-js`)"
 );
 
 const ndkVersionOption = new Option(
@@ -118,7 +123,8 @@ export const program = new Command("cmake-rn")
   .addOption(androidOption)
   .addOption(appleOption)
   .addOption(buildPathOption)
-  .addOption(outPathOption)
+  .addOption(outOption)
+  .addOption(outToBuildOption)
   .addOption(cleanOption)
   .addOption(ndkVersionOption)
   .addOption(androidSdkVersionOption)
@@ -167,6 +173,14 @@ export const program = new Command("cmake-rn")
             chalk.dim("(" + [...triplets].join(", ") + ")")
           );
         }
+      }
+
+      if (globalContext.outToBuild) {
+        assert(
+          globalContext.out === undefined,
+          "Cannot use --out with --out-to-build"
+        );
+        globalContext.out = path.join(buildPath, globalContext.configuration);
       }
 
       const tripletContext = [...triplets].map((triplet) => {


### PR DESCRIPTION
As a quick fix to address the issue of the output directory being misaligned with `cmake-js` and `node-gyp` (mentioned in #146).

Merging this PR will:
- Introduce a `--out-to-build` option which will output the prebuild artifact in the `build` directory (under "build/Release" or "build/Debug"), just like `cmake-js` and `node-gyp` does.

We might want to make this the default behaviour at some point.