### PR TITLE
Cherry pick the `findNodeAddonForBindings()` to path-utils

### DIFF
--- a/packages/host/src/node/path-utils.test.ts
+++ b/packages/host/src/node/path-utils.test.ts
@@ -386,7 +386,7 @@ describe("findNodeAddonForBindings()", () => {
     "addon_8": "Debug/addon_8.node",
   };
 
-  for (let [name, relPath] of Object.entries(expectedPaths)) {
+  for (const [name, relPath] of Object.entries(expectedPaths)) {
     it(`should look for addons in common paths (${name} in "${relPath}")`, (context) => {
       // Arrange
       const tempDirectoryPath = setupTempDirectory(context, {

--- a/packages/host/src/node/path-utils.ts
+++ b/packages/host/src/node/path-utils.ts
@@ -36,7 +36,9 @@ export function isNodeApiModule(modulePath: string): boolean {
     try {
       fs.accessSync(modulePath.endsWith(".node") ? modulePath : `${modulePath}.node`);
       return true;
-    } catch {}
+    } catch {
+      // intentionally left empty
+    }
   }
   const dir = path.dirname(modulePath);
   const baseName = path.basename(modulePath, ".node");


### PR DESCRIPTION
As requested on Discord, here is the cherry picked `findNodeAddonForBindings()` function (with tests).
It requires an additional change in `isNodeApiModule()` function, which was cherry-picked as well.