### PR TITLE
Derive tag on fork from .hermesversion in "react-native"

### DIFF
--- a/.changeset/upset-paws-follow.md
+++ b/.changeset/upset-paws-follow.md
@@ -1,0 +1,5 @@
+---
+"react-native-node-api": minor
+---
+
+Derive the tag used to clone the React Native fork bringing Node-API support from the .hermesversion file in the react-native package.


### PR DESCRIPTION
Merging this PR will:
- Derive the tag used when cloning the fork from the contents of the `.hermesversion` in "react-native" brought by the app: https://github.com/facebook/react-native/blob/v0.79.2/packages/react-native/sdks/.hermesversion

With this change, we can start pushing multiple tags to the React Native fork, to enable multiple React Native versions, ultimately fixing #157.