### PR TITLE
Add Jamie Birch to contributors

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,10 @@
     {
       "name": "Kræn Hansen",
       "url": "https://github.com/kraenhansen"
+    },
+    {
+      "name": "Jamie Birch",
+      "url": "https://github.com/shirakaba"
     }
   ],
   "license": "MIT",


### PR DESCRIPTION
My work on how to generate a Node-API module into an `.xcframework` for all Apple platforms was used as a [reference implementation](https://github.com/shirakaba/react-native-node-api-module-autolinking/blob/main/packages/example-node-api-module/CMakeLists.txt) for the Apple platforms support in `cmake-rn`.