### PR TITLE
React Native v0.79.5 (v0.79.4 & v0.79.3)

### DIFF
--- a/.changeset/ten-parts-check.md
+++ b/.changeset/ten-parts-check.md
@@ -1,0 +1,6 @@
+---
+"react-native-node-api-test-app": patch
+"react-native-node-api": patch
+---
+
+Adding support for React Native 0.79.3, 0.79.4 & 0.79.5

--- a/apps/test-app/package.json
+++ b/apps/test-app/package.json
@@ -28,7 +28,7 @@
     "mocha-remote-cli": "^1.13.2",
     "mocha-remote-react-native": "^1.13.2",
     "react": "19.0.0",
-    "react-native": "0.79.1",
+    "react-native": "0.79.5",
     "react-native-node-addon-examples": "*",
     "react-native-node-api": "*",
     "react-native-test-app": "^4.3.3"

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "@types/node": "^22.13.0",
         "eslint": "^9.19.0",
         "globals": "^16.0.0",
-        "react-native": "0.79.1",
+        "react-native": "0.79.5",
         "tsx": "^4.19.3",
         "typescript": "^5.7.3",
         "typescript-eslint": "^8.22.0"
@@ -51,7 +51,7 @@
         "mocha-remote-cli": "^1.13.2",
         "mocha-remote-react-native": "^1.13.2",
         "react": "19.0.0",
-        "react-native": "0.79.1",
+        "react-native": "0.79.5",
         "react-native-node-addon-examples": "*",
         "react-native-node-api": "*",
         "react-native-test-app": "^4.3.3"
@@ -5462,9 +5462,9 @@
       "link": true
     },
     "node_modules/@react-native/assets-registry": {
-      "version": "0.79.1",
-      "resolved": "https://registry.npmjs.org/@react-native/assets-registry/-/assets-registry-0.79.1.tgz",
-      "integrity": "sha512-q5BwZtL0YbaJRgofl8qrD9BNdGJkecTJNYG8VFOVQYXPTBa3ZSooip1aj0wrjoa0HloKx/Hmx5UMvuhfEsjn8A==",
+      "version": "0.79.5",
+      "resolved": "https://registry.npmjs.org/@react-native/assets-registry/-/assets-registry-0.79.5.tgz",
+      "integrity": "sha512-N4Kt1cKxO5zgM/BLiyzuuDNquZPiIgfktEQ6TqJ/4nKA8zr4e8KJgU6Tb2eleihDO4E24HmkvGc73naybKRz/w==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -5562,12 +5562,12 @@
       }
     },
     "node_modules/@react-native/community-cli-plugin": {
-      "version": "0.79.1",
-      "resolved": "https://registry.npmjs.org/@react-native/community-cli-plugin/-/community-cli-plugin-0.79.1.tgz",
-      "integrity": "sha512-hqCMQrMRi19G7yxEsYwV9A0MHB6Hri7B5dytRD7kU5vtz0Lzg1fZYYvmS0x9OdWJWPntmHA8xiijwM+4cT8cpQ==",
+      "version": "0.79.5",
+      "resolved": "https://registry.npmjs.org/@react-native/community-cli-plugin/-/community-cli-plugin-0.79.5.tgz",
+      "integrity": "sha512-ApLO1ARS8JnQglqS3JAHk0jrvB+zNW3dvNJyXPZPoygBpZVbf8sjvqeBiaEYpn8ETbFWddebC4HoQelDndnrrA==",
       "license": "MIT",
       "dependencies": {
-        "@react-native/dev-middleware": "0.79.1",
+        "@react-native/dev-middleware": "0.79.5",
         "chalk": "^4.0.0",
         "debug": "^2.2.0",
         "invariant": "^2.2.4",
@@ -5604,22 +5604,22 @@
       "license": "MIT"
     },
     "node_modules/@react-native/debugger-frontend": {
-      "version": "0.79.1",
-      "resolved": "https://registry.npmjs.org/@react-native/debugger-frontend/-/debugger-frontend-0.79.1.tgz",
-      "integrity": "sha512-IgbQM/djzBhkkjzIT/b36zwkc4UMxZLTKgRVJrSEjuwtOPmgfh/1F5m3OUitbMd4/e06VgN0vPLyBzToj1kiwA==",
+      "version": "0.79.5",
+      "resolved": "https://registry.npmjs.org/@react-native/debugger-frontend/-/debugger-frontend-0.79.5.tgz",
+      "integrity": "sha512-WQ49TRpCwhgUYo5/n+6GGykXmnumpOkl4Lr2l2o2buWU9qPOwoiBqJAtmWEXsAug4ciw3eLiVfthn5ufs0VB0A==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@react-native/dev-middleware": {
-      "version": "0.79.1",
-      "resolved": "https://registry.npmjs.org/@react-native/dev-middleware/-/dev-middleware-0.79.1.tgz",
-      "integrity": "sha512-xegUHwi6h8wOLIl/9ImZoIVVwzecE+ENGTELIrD2PsseBbtdRMKzZ8A1LTBjPPt3IjHPH6103JcSPwgepP6zFA==",
+      "version": "0.79.5",
+      "resolved": "https://registry.npmjs.org/@react-native/dev-middleware/-/dev-middleware-0.79.5.tgz",
+      "integrity": "sha512-U7r9M/SEktOCP/0uS6jXMHmYjj4ESfYCkNAenBjFjjsRWekiHE+U/vRMeO+fG9gq4UCcBAUISClkQCowlftYBw==",
       "license": "MIT",
       "dependencies": {
         "@isaacs/ttlcache": "^1.4.1",
-        "@react-native/debugger-frontend": "0.79.1",
+        "@react-native/debugger-frontend": "0.79.5",
         "chrome-launcher": "^0.15.2",
         "chromium-edge-launcher": "^0.2.0",
         "connect": "^3.6.5",
@@ -5650,9 +5650,9 @@
       "license": "MIT"
     },
     "node_modules/@react-native/gradle-plugin": {
-      "version": "0.79.1",
-      "resolved": "https://registry.npmjs.org/@react-native/gradle-plugin/-/gradle-plugin-0.79.1.tgz",
-      "integrity": "sha512-vfoNcOBig/+R7g3eqHkBSbSVkk0NMPzyXE5QY0V+/0flRa3kDZUHP2fr8ygoY/4rxbi05wPME2/dTEuoYcpnjg==",
+      "version": "0.79.5",
+      "resolved": "https://registry.npmjs.org/@react-native/gradle-plugin/-/gradle-plugin-0.79.5.tgz",
+      "integrity": "sha512-K3QhfFNKiWKF3HsCZCEoWwJPSMcPJQaeqOmzFP4RL8L3nkpgUwn74PfSCcKHxooVpS6bMvJFQOz7ggUZtNVT+A==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -5701,9 +5701,9 @@
       }
     },
     "node_modules/@react-native/normalize-colors": {
-      "version": "0.79.1",
-      "resolved": "https://registry.npmjs.org/@react-native/normalize-colors/-/normalize-colors-0.79.1.tgz",
-      "integrity": "sha512-Fj12xKyihZhrFH45ruqECd2JVx9lyYe+dyxO7MYgkqY6UENsSS3JKcfzjSNBZLW7NXts6JkbaqLQPwaHmPF7QA==",
+      "version": "0.79.5",
+      "resolved": "https://registry.npmjs.org/@react-native/normalize-colors/-/normalize-colors-0.79.5.tgz",
+      "integrity": "sha512-nGXMNMclZgzLUxijQQ38Dm3IAEhgxuySAWQHnljFtfB0JdaMwpe0Ox9H7Tp2OgrEA+EMEv+Od9ElKlHwGKmmvQ==",
       "license": "MIT"
     },
     "node_modules/@react-native/typescript-config": {
@@ -5711,29 +5711,6 @@
       "resolved": "https://registry.npmjs.org/@react-native/typescript-config/-/typescript-config-0.79.0.tgz",
       "integrity": "sha512-Zt3TRh7MVuWNZgPbhYWPSCL14dS0CyXZymTi7KLI3Bq/41cCOfMj3JZxX6y76L8Hs0jG5fMIGJ+Hwt2gK5RCiA==",
       "license": "MIT"
-    },
-    "node_modules/@react-native/virtualized-lists": {
-      "version": "0.79.1",
-      "resolved": "https://registry.npmjs.org/@react-native/virtualized-lists/-/virtualized-lists-0.79.1.tgz",
-      "integrity": "sha512-v1KeqJeVJXjc2mewjKQYSay7D7+VSacxryejuuVXlPE9E9wVbzMPCfPjbIS8C9nMC7a4rsRFilX7RVKYkeZaGg==",
-      "license": "MIT",
-      "dependencies": {
-        "invariant": "^2.2.4",
-        "nullthrows": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@types/react": "^19.0.0",
-        "react": "*",
-        "react-native": "*"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
     },
     "node_modules/@reporters/github": {
       "version": "1.7.2",
@@ -5977,9 +5954,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.14.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.14.1.tgz",
-      "integrity": "sha512-u0HuPQwe/dHrItgHHpmw3N2fYCR6x4ivMNbPHRkBVP4CvN+kiRrKHWk3i8tXiO/joPwXLMYvF9TTF0eqgHIuOw==",
+      "version": "22.16.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.16.3.tgz",
+      "integrity": "sha512-sr4Xz74KOUeYadexo1r8imhRtlVXcs+j3XK3TcoiYk7B1t3YRVJgtaD3cwX73NYb71pmVuMLNRhJ9XKdoDB74g==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -11345,19 +11322,19 @@
       "license": "MIT"
     },
     "node_modules/react-native": {
-      "version": "0.79.1",
-      "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.79.1.tgz",
-      "integrity": "sha512-MZQFEKyKPjqvyjuMUvH02elnmRQFzbS0yf46YOe9ktJWTZGwklsbJkRgaXJx9KA3SK6v1/QXVeCqZmrzho+1qw==",
+      "version": "0.79.5",
+      "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.79.5.tgz",
+      "integrity": "sha512-jVihwsE4mWEHZ9HkO1J2eUZSwHyDByZOqthwnGrVZCh6kTQBCm4v8dicsyDa6p0fpWNE5KicTcpX/XXl0ASJFg==",
       "license": "MIT",
       "dependencies": {
         "@jest/create-cache-key-function": "^29.7.0",
-        "@react-native/assets-registry": "0.79.1",
-        "@react-native/codegen": "0.79.1",
-        "@react-native/community-cli-plugin": "0.79.1",
-        "@react-native/gradle-plugin": "0.79.1",
-        "@react-native/js-polyfills": "0.79.1",
-        "@react-native/normalize-colors": "0.79.1",
-        "@react-native/virtualized-lists": "0.79.1",
+        "@react-native/assets-registry": "0.79.5",
+        "@react-native/codegen": "0.79.5",
+        "@react-native/community-cli-plugin": "0.79.5",
+        "@react-native/gradle-plugin": "0.79.5",
+        "@react-native/js-polyfills": "0.79.5",
+        "@react-native/normalize-colors": "0.79.5",
+        "@react-native/virtualized-lists": "0.79.5",
         "abort-controller": "^3.0.0",
         "anser": "^1.4.9",
         "ansi-regex": "^5.0.0",
@@ -11416,9 +11393,9 @@
       "link": true
     },
     "node_modules/react-native/node_modules/@react-native/codegen": {
-      "version": "0.79.1",
-      "resolved": "https://registry.npmjs.org/@react-native/codegen/-/codegen-0.79.1.tgz",
-      "integrity": "sha512-cTVXfCICkmUU6UvUpnLP4BE82O14JRuVz42cg/A19oasTaZmzHl0+uIDzt2cZEbt/N2sJ/EZnZL61qqpwbNXWQ==",
+      "version": "0.79.5",
+      "resolved": "https://registry.npmjs.org/@react-native/codegen/-/codegen-0.79.5.tgz",
+      "integrity": "sha512-FO5U1R525A1IFpJjy+KVznEinAgcs3u7IbnbRJUG9IH/MBXi2lEU2LtN+JarJ81MCfW4V2p0pg6t/3RGHFRrlQ==",
       "license": "MIT",
       "dependencies": {
         "glob": "^7.1.1",
@@ -11435,12 +11412,35 @@
       }
     },
     "node_modules/react-native/node_modules/@react-native/js-polyfills": {
-      "version": "0.79.1",
-      "resolved": "https://registry.npmjs.org/@react-native/js-polyfills/-/js-polyfills-0.79.1.tgz",
-      "integrity": "sha512-P8j11kdD+ehL5jqHSCM1BOl4SnJ+3rvGPpsagAqyngU6WSausISO7YFufltrWA7kdpHdnAL2HfJJ62szTRGShw==",
+      "version": "0.79.5",
+      "resolved": "https://registry.npmjs.org/@react-native/js-polyfills/-/js-polyfills-0.79.5.tgz",
+      "integrity": "sha512-a2wsFlIhvd9ZqCD5KPRsbCQmbZi6KxhRN++jrqG0FUTEV5vY7MvjjUqDILwJd2ZBZsf7uiDuClCcKqA+EEdbvw==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/react-native/node_modules/@react-native/virtualized-lists": {
+      "version": "0.79.5",
+      "resolved": "https://registry.npmjs.org/@react-native/virtualized-lists/-/virtualized-lists-0.79.5.tgz",
+      "integrity": "sha512-EUPM2rfGNO4cbI3olAbhPkIt3q7MapwCwAJBzUfWlZ/pu0PRNOnMQ1IvaXTf3TpeozXV52K1OdprLEI/kI5eUA==",
+      "license": "MIT",
+      "dependencies": {
+        "invariant": "^2.2.4",
+        "nullthrows": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/react": "^19.0.0",
+        "react": "*",
+        "react-native": "*"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-refresh": {
@@ -13089,7 +13089,7 @@
       }
     },
     "packages/cmake-rn": {
-      "version": "0.1.0",
+      "version": "0.2.1",
       "dependencies": {
         "@commander-js/extra-typings": "^13.1.0",
         "bufout": "^0.3.2",
@@ -13097,7 +13097,7 @@
         "cmake-js": "^7.3.1",
         "commander": "^13.1.0",
         "ora": "^8.2.0",
-        "react-native-node-api": "0.1.0"
+        "react-native-node-api": "0.3.0"
       },
       "bin": {
         "cmake-rn": "bin/cmake-rn.js"
@@ -13322,7 +13322,7 @@
     },
     "packages/ferric": {
       "name": "ferric-cli",
-      "version": "0.1.0",
+      "version": "0.2.1",
       "dependencies": {
         "@commander-js/extra-typings": "^13.1.0",
         "@napi-rs/cli": "3.0.0-alpha.89",
@@ -13330,7 +13330,7 @@
         "chalk": "^5.4.1",
         "commander": "^13.1.0",
         "ora": "^8.2.0",
-        "react-native-node-api": "0.1.0"
+        "react-native-node-api": "0.3.0"
       },
       "bin": {
         "ferric": "bin/ferric.js"
@@ -13339,7 +13339,7 @@
     "packages/ferric-example": {
       "version": "0.1.0",
       "devDependencies": {
-        "ferric-cli": "^0.1.0"
+        "ferric-cli": "^0.2.0"
       }
     },
     "packages/ferric/node_modules/@commander-js/extra-typings": {
@@ -13556,7 +13556,7 @@
       }
     },
     "packages/gyp-to-cmake": {
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "@commander-js/extra-typings": "^13.1.0",
         "commander": "^13.1.0",
@@ -13586,7 +13586,7 @@
     },
     "packages/host": {
       "name": "react-native-node-api",
-      "version": "0.1.0",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@commander-js/extra-typings": "^13.1.0",
@@ -13610,7 +13610,7 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.26.10",
-        "react-native": "0.79.1 || 0.79.2"
+        "react-native": "0.79.1 || 0.79.2 || 0.79.3 || 0.79.4 || 0.79.5"
       }
     },
     "packages/host/node_modules/@commander-js/extra-typings": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@types/node": "^22.13.0",
     "eslint": "^9.19.0",
     "globals": "^16.0.0",
-    "react-native": "0.79.1",
+    "react-native": "0.79.5",
     "typescript": "^5.7.3",
     "typescript-eslint": "^8.22.0",
     "tsx": "^4.19.3"

--- a/packages/host/package.json
+++ b/packages/host/package.json
@@ -95,6 +95,6 @@
   },
   "peerDependencies": {
     "@babel/core": "^7.26.10",
-    "react-native": "0.79.1 || 0.79.2"
+    "react-native": "0.79.1 || 0.79.2 || 0.79.3 || 0.79.4 || 0.79.5"
   }
 }


### PR DESCRIPTION
With #158 merged we're no longer pinned to a specific version of Hermes.

I've pushed a tag for the 0.79.3 cut of Hermes (also used by 0.79.4 and 0.79.5 - which is default for the latest version of Expo SDK 53) with the Node-API patch on-top:
[node-api-hermes-2025-06-04-RNv0.79.3-7f9a871eefeb2c3852365ee80f0b6733ec12ac3b](https://github.com/kraenhansen/hermes/tree/node-api-hermes-2025-06-04-RNv0.79.3-7f9a871eefeb2c3852365ee80f0b6733ec12ac3b)

Merging this PR will:
- Increase the peer dependency version range accepted by the host package.
- Upgrade the test app to start using 0.79.5.