### PR TITLE
Enable `RCT_USE_RN_DEP` in test app and assert `RCT_USE_PREBUILT_RNCORE` != `1`

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -76,16 +76,8 @@ jobs:
       - run: npm test
   test-ios:
     if: github.ref == 'refs/heads/main' || contains(github.event.pull_request.labels.*.name, 'Apple 🍎')
-    name: Test app (iOS${{ matrix.rn-deps-prebuilds && ' / RN deps prebuilds' || '' }}${{ matrix.rn-core-prebuilds && ' / RN core prebuilds' || '' }})
+    name: Test app (iOS)
     runs-on: macos-latest
-    strategy:
-      matrix:
-        rn-deps-prebuilds:
-          - true
-          - false
-        rn-core-prebuilds:
-          - true
-          - false
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -108,11 +100,6 @@ jobs:
           FERRIC_TARGETS: aarch64-apple-ios-sim
       - run: npm run pod-install
         working-directory: apps/test-app
-        env:
-          # Optionally enable experimental prebuilds
-          # https://reactnative.dev/blog/2025/08/12/react-native-0.81#experimental-precompiled-ios-builds
-          RCT_USE_PREBUILT_RNCORE: ${{ matrix.rn-core-prebuilds && '1' || '0' }}
-          RCT_USE_RN_DEP: ${{ matrix.rn-deps-prebuilds && '1' || '0' }}
       - name: Run tests (iOS)
         run: npm run test:ios:allTests
         # TODO: Enable release mode when it works

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -76,8 +76,16 @@ jobs:
       - run: npm test
   test-ios:
     if: github.ref == 'refs/heads/main' || contains(github.event.pull_request.labels.*.name, 'Apple 🍎')
-    name: Test app (iOS)
+    name: Test app (iOS${{ matrix.rn-deps-prebuilds && ' / RN deps prebuilds' || '' }}${{ matrix.rn-core-prebuilds && ' / RN core prebuilds' || '' }})
     runs-on: macos-latest
+    strategy:
+      matrix:
+        rn-deps-prebuilds:
+          - true
+          - false
+        rn-core-prebuilds:
+          - true
+          - false
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -100,6 +108,11 @@ jobs:
           FERRIC_TARGETS: aarch64-apple-ios-sim
       - run: npm run pod-install
         working-directory: apps/test-app
+        env:
+          # Optionally enable experimental prebuilds
+          # https://reactnative.dev/blog/2025/08/12/react-native-0.81#experimental-precompiled-ios-builds
+          RCT_USE_PREBUILT_RNCORE: ${{ matrix.rn-core-prebuilds && '1' || '0' }}
+          RCT_USE_RN_DEP: ${{ matrix.rn-deps-prebuilds && '1' || '0' }}
       - name: Run tests (iOS)
         run: npm run test:ios:allTests
         # TODO: Enable release mode when it works

--- a/apps/test-app/ios/Podfile
+++ b/apps/test-app/ios/Podfile
@@ -1,3 +1,6 @@
+# Opt into prebuilds of RN dependencies
+ENV['RCT_USE_RN_DEP'] = ENV['RCT_USE_RN_DEP'] || '1'
+
 ws_dir = Pathname.new(__dir__)
 ws_dir = ws_dir.parent until
   File.exist?("#{ws_dir}/node_modules/react-native-test-app/test_app.rb") ||

--- a/packages/host/react-native-node-api.podspec
+++ b/packages/host/react-native-node-api.podspec
@@ -41,26 +41,11 @@ Pod::Spec.new do |s|
     CMD
   }
 
-  # Use install_modules_dependencies helper to install the dependencies if React Native version >=0.71.0.
+  # Use install_modules_dependencies helper to install the dependencies (requires React Native version >=0.71.0).
   # See https://github.com/facebook/react-native/blob/febf6b7f33fdb4904669f99d795eba4c0f95d7bf/scripts/cocoapods/new_architecture.rb#L79.
   if respond_to?(:install_modules_dependencies, true)
     install_modules_dependencies(s)
   else
-    s.dependency "React-Core"
-    # Don't install the dependencies when we run `pod install` in the old architecture.
-    if ENV['RCT_NEW_ARCH_ENABLED'] == '1' then
-      # TODO: Re-visit these dependencies and flags and remove them if not needed.
-      s.compiler_flags = folly_compiler_flags + " -DRCT_NEW_ARCH_ENABLED=1"
-      s.pod_target_xcconfig    = {
-          "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost\"",
-          "OTHER_CPLUSPLUSFLAGS" => "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1",
-          "CLANG_CXX_LANGUAGE_STANDARD" => "c++17"
-      }
-      s.dependency "React-Codegen"
-      s.dependency "RCT-Folly"
-      s.dependency "RCTRequired"
-      s.dependency "RCTTypeSafety"
-      s.dependency "ReactCommon/turbomodule/core"
-    end
+    raise "This version of React Native is too old for React Native Node-API."
   end
 end

--- a/packages/host/scripts/patch-hermes.rb
+++ b/packages/host/scripts/patch-hermes.rb
@@ -1,5 +1,9 @@
 Pod::UI.warn "!!! PATCHING HERMES WITH NODE-API SUPPORT !!!"
 
+if ENV['RCT_USE_PREBUILT_RNCORE'] == '1'
+  raise "React Native Node-API cannot reliably patch JSI when React Native Core is prebuilt."
+end
+
 VENDORED_HERMES_DIR ||= `npx react-native-node-api vendor-hermes --silent '#{Pod::Config.instance.installation_root}'`.strip
 if Dir.exist?(VENDORED_HERMES_DIR)
   Pod::UI.info "Hermes vendored into #{VENDORED_HERMES_DIR.inspect}"

--- a/packages/host/src/node/podspec.test.ts
+++ b/packages/host/src/node/podspec.test.ts
@@ -1,0 +1,24 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import cp from "node:child_process";
+
+describe("Podspec", () => {
+  // We cannot support prebuilds of React Native Core since we're patching JSI
+  it(
+    "should error when RCT_USE_PREBUILT_RNCORE is set",
+    // We cannot call `pod` on non-macOS systems
+    { skip: process.platform !== "darwin" },
+    () => {
+      const { status, stdout } = cp.spawnSync("pod", ["spec", "lint"], {
+        env: { ...process.env, RCT_USE_PREBUILT_RNCORE: "1" },
+        encoding: "utf-8",
+      });
+
+      assert.notEqual(status, 0);
+      assert.match(
+        stdout,
+        /React Native Node-API cannot reliably patch JSI when React Native Core is prebuilt/,
+      );
+    },
+  );
+});


### PR DESCRIPTION
As an alternative to https://github.com/callstackincubator/react-native-node-api/pull/207 want the test app to enable `RCT_USE_RN_DEP` (since we can and this is faster) and assert that `RCT_USE_PREBUILT_RNCORE` is never enabled (since we cannot support this as the prebuild of React Native Core use a JSI header which we have to patch - resulting in runtime crashes when enabled with our patched Hermes).