### PR TITLE
Check Hermes override pre-condition from Host package when building for Android

### DIFF
--- a/.changeset/many-candies-retire.md
+++ b/.changeset/many-candies-retire.md
@@ -1,0 +1,5 @@
+---
+"react-native-node-api": patch
+---
+
+Fix auto-linking from Gradle builds on Windows

--- a/.changeset/silver-suits-double.md
+++ b/.changeset/silver-suits-double.md
@@ -1,0 +1,5 @@
+---
+"react-native-node-api": minor
+---
+
+Assert that REACT_NATIVE_OVERRIDE_HERMES_DIR is set when Android / Gradle projects depend on the host package

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -3,6 +3,8 @@ name: Check
 env:
   # Version here should match the one in React Native template and packages/cmake-rn/src/cli.ts
   NDK_VERSION: 27.1.12297006
+  # Enabling the Gradle test on CI (disabled by default because it downloads a lot)
+  ENABLE_GRADLE_TESTS: true
 
 on:
   push:

--- a/packages/host/android/build.gradle
+++ b/packages/host/android/build.gradle
@@ -150,12 +150,13 @@ task checkHermesOverride {
     }
 }
 
+def cliPath = file("../bin/react-native-node-api.mjs")
+
 // Custom task to fetch jniLibs paths via CLI
 task linkNodeApiModules {
   doLast {
     exec {
-      // TODO: Support --strip-path-suffix
-      commandLine 'npx', 'react-native-node-api', 'link', '--android', rootProject.rootDir.absolutePath
+      commandLine cliPath, 'link', '--android', rootProject.rootDir.absolutePath
       standardOutput = System.out
       errorOutput = System.err
       // Enable color output

--- a/packages/host/android/build.gradle
+++ b/packages/host/android/build.gradle
@@ -134,6 +134,22 @@ dependencies {
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 }
 
+task checkHermesOverride {
+    doFirst {
+        if (!System.getenv("REACT_NATIVE_OVERRIDE_HERMES_DIR")) {
+            throw new GradleException([
+                "React Native Node-API needs a custom version of Hermes with Node-API enabled.",
+                "Run the following in your terminal, to clone Hermes and instruct React Native to use it:",
+                "",
+                "export REACT_NATIVE_OVERRIDE_HERMES_DIR=`npx react-native-node-api vendor-hermes --silent --force`",
+                "",
+                "And follow this guide to build React Native from source:",
+                "https://reactnative.dev/contributing/how-to-build-from-source#update-your-project-to-build-from-source"
+            ].join('\n'))
+        }
+    }
+}
+
 // Custom task to fetch jniLibs paths via CLI
 task linkNodeApiModules {
   doLast {
@@ -150,5 +166,5 @@ task linkNodeApiModules {
   }
 }
 
-preBuild.dependsOn linkNodeApiModules
+preBuild.dependsOn checkHermesOverride, linkNodeApiModules
 

--- a/packages/host/android/build.gradle
+++ b/packages/host/android/build.gradle
@@ -1,5 +1,6 @@
 import java.nio.file.Paths
 import groovy.json.JsonSlurper
+import org.gradle.internal.os.OperatingSystem
 
 buildscript {
   ext.getExtOrDefault = {name ->
@@ -150,13 +151,14 @@ task checkHermesOverride {
     }
 }
 
+def commandLinePrefix = OperatingSystem.current().isWindows() ? ["cmd", "/c", "node"] : []
 def cliPath = file("../bin/react-native-node-api.mjs")
 
 // Custom task to fetch jniLibs paths via CLI
 task linkNodeApiModules {
   doLast {
     exec {
-      commandLine cliPath, 'link', '--android', rootProject.rootDir.absolutePath
+      commandLine commandLinePrefix + [cliPath, 'link', '--android', rootProject.rootDir.absolutePath]
       standardOutput = System.out
       errorOutput = System.err
       // Enable color output

--- a/packages/host/package.json
+++ b/packages/host/package.json
@@ -47,6 +47,7 @@
     "build-weak-node-api": "cmake-rn --no-auto-link --no-weak-node-api-linkage --xcframework-extension --source ./weak-node-api --out ./weak-node-api",
     "build-weak-node-api:all-triplets": "cmake-rn --android --apple --no-auto-link --no-weak-node-api-linkage --xcframework-extension --source ./weak-node-api --out ./weak-node-api",
     "test": "tsx --test --test-reporter=@reporters/github --test-reporter-destination=stdout --test-reporter=spec --test-reporter-destination=stdout src/node/**/*.test.ts src/node/*.test.ts",
+    "test:gradle": "ENABLE_GRADLE_TESTS=true node --run test",
     "bootstrap": "node --run copy-node-api-headers && node --run generate-weak-node-api-injector && node --run generate-weak-node-api && node --run build-weak-node-api",
     "prerelease": "node --run copy-node-api-headers && node --run generate-weak-node-api-injector && node --run generate-weak-node-api && node --run build-weak-node-api:all-triplets"
   },

--- a/packages/host/src/node/cli/bin.test.ts
+++ b/packages/host/src/node/cli/bin.test.ts
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import cp from "node:child_process";
+import path from "node:path";
+
+const PACKAGE_ROOT = path.join(__dirname, "../../..");
+const BIN_PATH = path.join(PACKAGE_ROOT, "bin/react-native-node-api.mjs");
+
+describe("bin", () => {
+  describe("help command", () => {
+    it("should succeed with a mention of usage", () => {
+      const { status, stdout, stderr } = cp.spawnSync(
+        process.execPath,
+        [BIN_PATH, "help"],
+        {
+          cwd: PACKAGE_ROOT,
+          encoding: "utf8",
+        },
+      );
+
+      assert.equal(
+        status,
+        0,
+        `Expected success (got ${status}): ${stdout} ${stderr}`,
+      );
+      assert.match(stdout, /Usage: react-native-node-api/);
+    });
+  });
+
+  describe("link command", () => {
+    it("should succeed with a mention of Node-API modules", () => {
+      const { status, stdout, stderr } = cp.spawnSync(
+        process.execPath,
+        [BIN_PATH, "link", "--android", "--apple"],
+        {
+          cwd: PACKAGE_ROOT,
+          encoding: "utf8",
+        },
+      );
+
+      assert.equal(
+        status,
+        0,
+        `Expected success (got ${status}): ${stdout} ${stderr}`,
+      );
+      assert.match(stdout, /Auto-linking Node-API modules/);
+    });
+  });
+});

--- a/packages/host/src/node/cli/bin.test.ts
+++ b/packages/host/src/node/cli/bin.test.ts
@@ -23,7 +23,11 @@ describe("bin", () => {
         0,
         `Expected success (got ${status}): ${stdout} ${stderr}`,
       );
-      assert.match(stdout, /Usage: react-native-node-api/);
+      assert.match(
+        stdout,
+        /Usage: react-native-node-api/,
+        `Failed to find expected output (stdout: ${stdout} stderr: ${stderr})`,
+      );
     });
   });
 
@@ -43,7 +47,11 @@ describe("bin", () => {
         0,
         `Expected success (got ${status}): ${stdout} ${stderr}`,
       );
-      assert.match(stdout, /Auto-linking Node-API modules/);
+      assert.match(
+        stdout + stderr,
+        /Auto-linking Node-API modules/,
+        `Failed to find expected output (stdout: ${stdout} stderr: ${stderr})`,
+      );
     });
   });
 });

--- a/packages/host/src/node/gradle.test.ts
+++ b/packages/host/src/node/gradle.test.ts
@@ -42,4 +42,20 @@ describe("Gradle tasks", () => {
       );
     });
   });
+
+  describe("linkNodeApiModules task", () => {
+    it("should call the CLI to autolink", () => {
+      const { status, stdout, stderr } = cp.spawnSync(
+        "sh",
+        ["gradlew", "react-native-node-api:linkNodeApiModules"],
+        {
+          cwd: TEST_APP_ANDROID_PATH,
+          encoding: "utf-8",
+        },
+      );
+
+      assert.equal(status, 0, `Expected failure: ${stdout} ${stderr}`);
+      assert.match(stdout, /Auto-linking Node-API modules/);
+    });
+  });
 });

--- a/packages/host/src/node/gradle.test.ts
+++ b/packages/host/src/node/gradle.test.ts
@@ -58,7 +58,7 @@ describe(
           },
         );
 
-        assert.equal(status, 0, `Expected failure: ${stdout} ${stderr}`);
+        assert.equal(status, 0, `Expected success: ${stdout} ${stderr}`);
         assert.match(stdout, /Auto-linking Node-API modules/);
       });
     });

--- a/packages/host/src/node/gradle.test.ts
+++ b/packages/host/src/node/gradle.test.ts
@@ -7,55 +7,60 @@ const PACKAGE_ROOT = path.join(__dirname, "../..");
 const MONOREPO_ROOT = path.join(PACKAGE_ROOT, "../..");
 const TEST_APP_ANDROID_PATH = path.join(MONOREPO_ROOT, "apps/test-app/android");
 
-describe("Gradle tasks", () => {
-  describe("checkHermesOverride task", () => {
-    it("should fail if REACT_NATIVE_OVERRIDE_HERMES_DIR is not set", () => {
-      const { status, stdout, stderr } = cp.spawnSync(
-        "sh",
-        ["gradlew", "react-native-node-api:checkHermesOverride"],
-        {
-          cwd: TEST_APP_ANDROID_PATH,
-          env: {
-            ...process.env,
-            REACT_NATIVE_OVERRIDE_HERMES_DIR: undefined,
+describe(
+  "Gradle tasks",
+  // Skipping these tests by default, as they download a lot and takes a long time
+  { skip: process.env.ENABLE_GRADLE_TESTS !== "true" },
+  () => {
+    describe("checkHermesOverride task", () => {
+      it("should fail if REACT_NATIVE_OVERRIDE_HERMES_DIR is not set", () => {
+        const { status, stdout, stderr } = cp.spawnSync(
+          "sh",
+          ["gradlew", "react-native-node-api:checkHermesOverride"],
+          {
+            cwd: TEST_APP_ANDROID_PATH,
+            env: {
+              ...process.env,
+              REACT_NATIVE_OVERRIDE_HERMES_DIR: undefined,
+            },
+            encoding: "utf-8",
           },
-          encoding: "utf-8",
-        },
-      );
+        );
 
-      assert.notEqual(status, 0, `Expected failure: ${stdout} ${stderr}`);
-      assert.match(
-        stderr,
-        /React Native Node-API needs a custom version of Hermes with Node-API enabled/,
-      );
-      assert.match(
-        stderr,
-        /Run the following in your terminal, to clone Hermes and instruct React Native to use it/,
-      );
-      assert.match(
-        stderr,
-        /export REACT_NATIVE_OVERRIDE_HERMES_DIR=`npx react-native-node-api vendor-hermes --silent --force`/,
-      );
-      assert.match(
-        stderr,
-        /And follow this guide to build React Native from source/,
-      );
+        assert.notEqual(status, 0, `Expected failure: ${stdout} ${stderr}`);
+        assert.match(
+          stderr,
+          /React Native Node-API needs a custom version of Hermes with Node-API enabled/,
+        );
+        assert.match(
+          stderr,
+          /Run the following in your terminal, to clone Hermes and instruct React Native to use it/,
+        );
+        assert.match(
+          stderr,
+          /export REACT_NATIVE_OVERRIDE_HERMES_DIR=`npx react-native-node-api vendor-hermes --silent --force`/,
+        );
+        assert.match(
+          stderr,
+          /And follow this guide to build React Native from source/,
+        );
+      });
     });
-  });
 
-  describe("linkNodeApiModules task", () => {
-    it("should call the CLI to autolink", () => {
-      const { status, stdout, stderr } = cp.spawnSync(
-        "sh",
-        ["gradlew", "react-native-node-api:linkNodeApiModules"],
-        {
-          cwd: TEST_APP_ANDROID_PATH,
-          encoding: "utf-8",
-        },
-      );
+    describe("linkNodeApiModules task", () => {
+      it("should call the CLI to autolink", () => {
+        const { status, stdout, stderr } = cp.spawnSync(
+          "sh",
+          ["gradlew", "react-native-node-api:linkNodeApiModules"],
+          {
+            cwd: TEST_APP_ANDROID_PATH,
+            encoding: "utf-8",
+          },
+        );
 
-      assert.equal(status, 0, `Expected failure: ${stdout} ${stderr}`);
-      assert.match(stdout, /Auto-linking Node-API modules/);
+        assert.equal(status, 0, `Expected failure: ${stdout} ${stderr}`);
+        assert.match(stdout, /Auto-linking Node-API modules/);
+      });
     });
-  });
-});
+  },
+);

--- a/packages/host/src/node/gradle.test.ts
+++ b/packages/host/src/node/gradle.test.ts
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import cp from "node:child_process";
+import path from "node:path";
+
+const PACKAGE_ROOT = path.join(__dirname, "../..");
+const MONOREPO_ROOT = path.join(PACKAGE_ROOT, "../..");
+const TEST_APP_ANDROID_PATH = path.join(MONOREPO_ROOT, "apps/test-app/android");
+
+describe("Gradle tasks", () => {
+  describe("checkHermesOverride task", () => {
+    it("should fail if REACT_NATIVE_OVERRIDE_HERMES_DIR is not set", () => {
+      const { status, stdout, stderr } = cp.spawnSync(
+        "sh",
+        ["gradlew", "react-native-node-api:checkHermesOverride"],
+        {
+          cwd: TEST_APP_ANDROID_PATH,
+          env: {
+            ...process.env,
+            REACT_NATIVE_OVERRIDE_HERMES_DIR: undefined,
+          },
+          encoding: "utf-8",
+        },
+      );
+
+      assert.notEqual(status, 0, `Expected failure: ${stdout} ${stderr}`);
+      assert.match(
+        stderr,
+        /React Native Node-API needs a custom version of Hermes with Node-API enabled/,
+      );
+      assert.match(
+        stderr,
+        /Run the following in your terminal, to clone Hermes and instruct React Native to use it/,
+      );
+      assert.match(
+        stderr,
+        /export REACT_NATIVE_OVERRIDE_HERMES_DIR=`npx react-native-node-api vendor-hermes --silent --force`/,
+      );
+      assert.match(
+        stderr,
+        /And follow this guide to build React Native from source/,
+      );
+    });
+  });
+});


### PR DESCRIPTION
Ideally, we would have liked to inject the overriding of Hermes source directory from within, but haven't found a way to do that. Until we find a way we can assert that it's done by the caller.

Merging this PR will:
- Add a `checkHermesOverride` to the host package Gradle build script to ensure `REACT_NATIVE_OVERRIDE_HERMES_DIR` is set (fixing https://github.com/callstackincubator/react-native-node-api/issues/163).
- Drive-by add a test to verify the `linkNodeApiModules` task is calling into the CLI to execute auto-linking.
- Drive-by fix of calling into the CLI to link on Windows.