### PR TITLE
Refactor CLIs into using a shared utility package (more)

### DIFF
--- a/packages/cli-utils/src/actions.ts
+++ b/packages/cli-utils/src/actions.ts
@@ -4,10 +4,14 @@ import * as commander from "@commander-js/extra-typings";
 
 import { UsageError } from "./errors.js";
 
-function wrapAction<Command extends commander.Command, Args extends unknown[]>(
-  fn: (this: Command, ...args: Args) => void | Promise<void>,
-) {
-  return async function (this: Command, ...args: Args) {
+export function wrapAction<
+  Args extends unknown[],
+  Opts extends commander.OptionValues,
+  GlobalOpts extends commander.OptionValues,
+  Command extends commander.Command<Args, Opts, GlobalOpts>,
+  ActionArgs extends unknown[],
+>(fn: (this: Command, ...args: ActionArgs) => void | Promise<void>) {
+  return async function (this: Command, ...args: ActionArgs) {
     try {
       await fn.call(this, ...args);
     } catch (error) {
@@ -34,17 +38,3 @@ function wrapAction<Command extends commander.Command, Args extends unknown[]>(
     }
   };
 }
-
-import { Command } from "@commander-js/extra-typings";
-
-// Patch Command to wrap all actions with our error handler
-
-// eslint-disable-next-line @typescript-eslint/unbound-method
-const originalAction = Command.prototype.action;
-
-Command.prototype.action = function action<Command extends commander.Command>(
-  this: Command,
-  fn: Parameters<typeof originalAction>[0],
-) {
-  return originalAction.call(this, wrapAction(fn));
-};

--- a/packages/cli-utils/src/actions.ts
+++ b/packages/cli-utils/src/actions.ts
@@ -18,11 +18,18 @@ export function wrapAction<
       process.exitCode = 1;
       if (error instanceof SpawnFailure) {
         error.flushOutput("both");
+      } else if (
+        error instanceof Error &&
+        error.cause instanceof SpawnFailure
+      ) {
+        error.cause.flushOutput("both");
       }
+      // Ensure some visual distance to the previous output
+      console.error();
       if (error instanceof UsageError || error instanceof SpawnFailure) {
         console.error(chalk.red("ERROR"), error.message);
         if (error.cause instanceof Error) {
-          console.error(chalk.red("CAUSE"), error.cause.message);
+          console.error(chalk.blue("CAUSE"), error.cause.message);
         }
         if (error instanceof UsageError && error.fix) {
           console.error(

--- a/packages/cmake-rn/src/cli.ts
+++ b/packages/cmake-rn/src/cli.ts
@@ -10,6 +10,7 @@ import {
   spawn,
   oraPromise,
   assertFixable,
+  wrapAction,
 } from "@react-native-node-api/cli-utils";
 import { isSupportedTriplet } from "react-native-node-api";
 
@@ -131,7 +132,7 @@ for (const platform of platforms) {
 }
 
 program = program.action(
-  async ({ target: requestedTargets, ...baseOptions }) => {
+  wrapAction(async ({ target: requestedTargets, ...baseOptions }) => {
     assertFixable(
       fs.existsSync(path.join(baseOptions.source, "CMakeLists.txt")),
       `No CMakeLists.txt found in source directory: ${chalk.dim(baseOptions.source)}`,
@@ -245,7 +246,7 @@ program = program.action(
         baseOptions,
       );
     }
-  },
+  }),
 );
 
 function getTargetsSummary(

--- a/packages/ferric/src/build.ts
+++ b/packages/ferric/src/build.ts
@@ -7,6 +7,7 @@ import {
   Option,
   oraPromise,
   assertFixable,
+  wrapAction,
 } from "@react-native-node-api/cli-utils";
 
 import {
@@ -116,195 +117,197 @@ export const buildCommand = new Command("build")
   .addOption(configurationOption)
   .addOption(xcframeworkExtensionOption)
   .action(
-    async ({
-      target: targetArg,
-      apple,
-      android,
-      ndkVersion,
-      output: outputPath,
-      configuration,
-      xcframeworkExtension,
-    }) => {
-      const targets = new Set([...targetArg]);
-      if (apple) {
-        for (const target of APPLE_TARGETS) {
-          targets.add(target);
-        }
-      }
-      if (android) {
-        for (const target of ANDROID_TARGETS) {
-          targets.add(target);
-        }
-      }
-
-      if (targets.size === 0) {
-        if (isAndroidSupported()) {
-          if (process.arch === "arm64") {
-            targets.add("aarch64-linux-android");
-          } else if (process.arch === "x64") {
-            targets.add("x86_64-linux-android");
+    wrapAction(
+      async ({
+        target: targetArg,
+        apple,
+        android,
+        ndkVersion,
+        output: outputPath,
+        configuration,
+        xcframeworkExtension,
+      }) => {
+        const targets = new Set([...targetArg]);
+        if (apple) {
+          for (const target of APPLE_TARGETS) {
+            targets.add(target);
           }
         }
-        if (isAppleSupported()) {
-          if (process.arch === "arm64") {
-            targets.add("aarch64-apple-ios-sim");
+        if (android) {
+          for (const target of ANDROID_TARGETS) {
+            targets.add(target);
           }
         }
-        console.error(
-          chalk.yellowBright("ℹ"),
-          chalk.dim(
-            `Using default targets, pass ${chalk.italic(
-              "--android",
-            )}, ${chalk.italic("--apple")} or individual ${chalk.italic(
-              "--target",
-            )} options, to avoid this.`,
-          ),
-        );
-      }
-      ensureCargo();
-      ensureInstalledTargets(targets);
 
-      const appleTargets = filterTargetsByPlatform(targets, "apple");
-      const androidTargets = filterTargetsByPlatform(targets, "android");
-
-      const targetsDescription =
-        targets.size +
-        (targets.size === 1 ? " target" : " targets") +
-        chalk.dim(" (" + [...targets].join(", ") + ")");
-      const [appleLibraries, androidLibraries] = await oraPromise(
-        Promise.all([
-          Promise.all(
-            appleTargets.map(
-              async (target) =>
-                [target, await build({ configuration, target })] as const,
+        if (targets.size === 0) {
+          if (isAndroidSupported()) {
+            if (process.arch === "arm64") {
+              targets.add("aarch64-linux-android");
+            } else if (process.arch === "x64") {
+              targets.add("x86_64-linux-android");
+            }
+          }
+          if (isAppleSupported()) {
+            if (process.arch === "arm64") {
+              targets.add("aarch64-apple-ios-sim");
+            }
+          }
+          console.error(
+            chalk.yellowBright("ℹ"),
+            chalk.dim(
+              `Using default targets, pass ${chalk.italic(
+                "--android",
+              )}, ${chalk.italic("--apple")} or individual ${chalk.italic(
+                "--target",
+              )} options, to avoid this.`,
             ),
-          ),
-          Promise.all(
-            androidTargets.map(
-              async (target) =>
-                [
-                  target,
-                  await build({
-                    configuration,
+          );
+        }
+        ensureCargo();
+        ensureInstalledTargets(targets);
+
+        const appleTargets = filterTargetsByPlatform(targets, "apple");
+        const androidTargets = filterTargetsByPlatform(targets, "android");
+
+        const targetsDescription =
+          targets.size +
+          (targets.size === 1 ? " target" : " targets") +
+          chalk.dim(" (" + [...targets].join(", ") + ")");
+        const [appleLibraries, androidLibraries] = await oraPromise(
+          Promise.all([
+            Promise.all(
+              appleTargets.map(
+                async (target) =>
+                  [target, await build({ configuration, target })] as const,
+              ),
+            ),
+            Promise.all(
+              androidTargets.map(
+                async (target) =>
+                  [
                     target,
-                    ndkVersion,
-                    androidApiLevel: ANDROID_API_LEVEL,
-                  }),
-                ] as const,
+                    await build({
+                      configuration,
+                      target,
+                      ndkVersion,
+                      androidApiLevel: ANDROID_API_LEVEL,
+                    }),
+                  ] as const,
+              ),
             ),
-          ),
-        ]),
-        {
-          text: `Building ${targetsDescription}`,
-          successText: `Built ${targetsDescription}`,
-          failText: (error: Error) => `Failed to build: ${error.message}`,
-        },
-      );
-
-      if (androidLibraries.length > 0) {
-        const libraryPathByTriplet = Object.fromEntries(
-          androidLibraries.map(([target, outputPath]) => [
-            ANDROID_TRIPLET_PER_TARGET[target],
-            outputPath,
           ]),
-        ) as Record<AndroidTriplet, string>;
-
-        const androidLibsFilename = determineAndroidLibsFilename(
-          Object.values(libraryPathByTriplet),
-        );
-        const androidLibsOutputPath = path.resolve(
-          outputPath,
-          androidLibsFilename,
-        );
-
-        await oraPromise(
-          createAndroidLibsDirectory({
-            outputPath: androidLibsOutputPath,
-            libraryPathByTriplet,
-            autoLink: true,
-          }),
           {
-            text: "Assembling Android libs directory",
-            successText: `Android libs directory assembled into ${prettyPath(
-              androidLibsOutputPath,
-            )}`,
-            failText: ({ message }) =>
-              `Failed to assemble Android libs directory: ${message}`,
+            text: `Building ${targetsDescription}`,
+            successText: `Built ${targetsDescription}`,
+            failText: (error: Error) => `Failed to build: ${error.message}`,
           },
         );
-      }
 
-      if (appleLibraries.length > 0) {
-        const libraryPaths = await combineLibraries(appleLibraries);
-        const frameworkPaths = libraryPaths.map(createAppleFramework);
-        const xcframeworkFilename = determineXCFrameworkFilename(
-          frameworkPaths,
-          xcframeworkExtension ? ".xcframework" : ".apple.node",
-        );
+        if (androidLibraries.length > 0) {
+          const libraryPathByTriplet = Object.fromEntries(
+            androidLibraries.map(([target, outputPath]) => [
+              ANDROID_TRIPLET_PER_TARGET[target],
+              outputPath,
+            ]),
+          ) as Record<AndroidTriplet, string>;
 
-        // Create the xcframework
-        const xcframeworkOutputPath = path.resolve(
-          outputPath,
-          xcframeworkFilename,
-        );
+          const androidLibsFilename = determineAndroidLibsFilename(
+            Object.values(libraryPathByTriplet),
+          );
+          const androidLibsOutputPath = path.resolve(
+            outputPath,
+            androidLibsFilename,
+          );
 
-        await oraPromise(
-          createXCframework({
-            outputPath: xcframeworkOutputPath,
+          await oraPromise(
+            createAndroidLibsDirectory({
+              outputPath: androidLibsOutputPath,
+              libraryPathByTriplet,
+              autoLink: true,
+            }),
+            {
+              text: "Assembling Android libs directory",
+              successText: `Android libs directory assembled into ${prettyPath(
+                androidLibsOutputPath,
+              )}`,
+              failText: ({ message }) =>
+                `Failed to assemble Android libs directory: ${message}`,
+            },
+          );
+        }
+
+        if (appleLibraries.length > 0) {
+          const libraryPaths = await combineLibraries(appleLibraries);
+          const frameworkPaths = libraryPaths.map(createAppleFramework);
+          const xcframeworkFilename = determineXCFrameworkFilename(
             frameworkPaths,
-            autoLink: true,
+            xcframeworkExtension ? ".xcframework" : ".apple.node",
+          );
+
+          // Create the xcframework
+          const xcframeworkOutputPath = path.resolve(
+            outputPath,
+            xcframeworkFilename,
+          );
+
+          await oraPromise(
+            createXCframework({
+              outputPath: xcframeworkOutputPath,
+              frameworkPaths,
+              autoLink: true,
+            }),
+            {
+              text: "Assembling XCFramework",
+              successText: `XCFramework assembled into ${chalk.dim(
+                path.relative(process.cwd(), xcframeworkOutputPath),
+              )}`,
+              failText: ({ message }) =>
+                `Failed to assemble XCFramework: ${message}`,
+            },
+          );
+        }
+
+        const libraryName = determineLibraryBasename([
+          ...androidLibraries.map(([, outputPath]) => outputPath),
+          ...appleLibraries.map(([, outputPath]) => outputPath),
+        ]);
+
+        const declarationsFilename = `${libraryName}.d.ts`;
+        const declarationsPath = path.join(outputPath, declarationsFilename);
+        await oraPromise(
+          generateTypeScriptDeclarations({
+            outputFilename: declarationsFilename,
+            createPath: process.cwd(),
+            outputPath,
           }),
           {
-            text: "Assembling XCFramework",
-            successText: `XCFramework assembled into ${chalk.dim(
-              path.relative(process.cwd(), xcframeworkOutputPath),
+            text: "Generating TypeScript declarations",
+            successText: `Generated TypeScript declarations ${prettyPath(
+              declarationsPath,
             )}`,
-            failText: ({ message }) =>
-              `Failed to assemble XCFramework: ${message}`,
+            failText: (error) =>
+              `Failed to generate TypeScript declarations: ${error.message}`,
           },
         );
-      }
 
-      const libraryName = determineLibraryBasename([
-        ...androidLibraries.map(([, outputPath]) => outputPath),
-        ...appleLibraries.map(([, outputPath]) => outputPath),
-      ]);
+        const entrypointPath = path.join(outputPath, `${libraryName}.js`);
 
-      const declarationsFilename = `${libraryName}.d.ts`;
-      const declarationsPath = path.join(outputPath, declarationsFilename);
-      await oraPromise(
-        generateTypeScriptDeclarations({
-          outputFilename: declarationsFilename,
-          createPath: process.cwd(),
-          outputPath,
-        }),
-        {
-          text: "Generating TypeScript declarations",
-          successText: `Generated TypeScript declarations ${prettyPath(
-            declarationsPath,
-          )}`,
-          failText: (error) =>
-            `Failed to generate TypeScript declarations: ${error.message}`,
-        },
-      );
-
-      const entrypointPath = path.join(outputPath, `${libraryName}.js`);
-
-      await oraPromise(
-        generateEntrypoint({
-          libraryName,
-          outputPath: entrypointPath,
-        }),
-        {
-          text: `Generating entrypoint`,
-          successText: `Generated entrypoint into ${prettyPath(
-            entrypointPath,
-          )}`,
-          failText: (error) =>
-            `Failed to generate entrypoint: ${error.message}`,
-        },
-      );
-    },
+        await oraPromise(
+          generateEntrypoint({
+            libraryName,
+            outputPath: entrypointPath,
+          }),
+          {
+            text: `Generating entrypoint`,
+            successText: `Generated entrypoint into ${prettyPath(
+              entrypointPath,
+            )}`,
+            failText: (error) =>
+              `Failed to generate entrypoint: ${error.message}`,
+          },
+        );
+      },
+    ),
   );
 
 async function combineLibraries(

--- a/packages/gyp-to-cmake/src/cli.ts
+++ b/packages/gyp-to-cmake/src/cli.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 
-import { Command } from "@react-native-node-api/cli-utils";
+import { Command, wrapAction } from "@react-native-node-api/cli-utils";
 
 import { readBindingFile } from "./gyp.js";
 import {
@@ -67,18 +67,20 @@ export const program = new Command("gyp-to-cmake")
     "Path to the binding.gyp file or directory to traverse recursively",
     process.cwd(),
   )
-  .action((targetPath: string, { pathTransforms }) => {
-    const options: TransformOptions = {
-      unsupportedBehaviour: "throw",
-      disallowUnknownProperties: false,
-      transformWinPathsToPosix: pathTransforms,
-    };
-    const stat = fs.statSync(targetPath);
-    if (stat.isFile()) {
-      transformBindingGypFile(targetPath, options);
-    } else if (stat.isDirectory()) {
-      transformBindingGypsRecursively(targetPath, options);
-    } else {
-      throw new Error(`Expected either a file or a directory: ${targetPath}`);
-    }
-  });
+  .action(
+    wrapAction((targetPath: string, { pathTransforms }) => {
+      const options: TransformOptions = {
+        unsupportedBehaviour: "throw",
+        disallowUnknownProperties: false,
+        transformWinPathsToPosix: pathTransforms,
+      };
+      const stat = fs.statSync(targetPath);
+      if (stat.isFile()) {
+        transformBindingGypFile(targetPath, options);
+      } else if (stat.isDirectory()) {
+        transformBindingGypsRecursively(targetPath, options);
+      } else {
+        throw new Error(`Expected either a file or a directory: ${targetPath}`);
+      }
+    }),
+  );

--- a/packages/host/src/node/cli/hermes.ts
+++ b/packages/host/src/node/cli/hermes.ts
@@ -3,10 +3,12 @@ import fs from "node:fs";
 import path from "node:path";
 
 import {
+  chalk,
   Command,
   oraPromise,
   spawn,
-  SpawnFailure,
+  UsageError,
+  wrapAction,
 } from "@react-native-node-api/cli-utils";
 import { packageDirectorySync } from "pkg-dir";
 
@@ -24,8 +26,8 @@ export const command = new Command("vendor-hermes")
     "Don't check timestamps of input files to skip unnecessary rebuilds",
     false,
   )
-  .action(async (from, { force, silent }) => {
-    try {
+  .action(
+    wrapAction(async (from, { force, silent }) => {
       const appPackageRoot = packageDirectorySync({ cwd: from });
       assert(appPackageRoot, "Failed to find package root");
       const reactNativePath = path.dirname(
@@ -124,11 +126,5 @@ export const command = new Command("vendor-hermes")
         },
       );
       console.log(hermesPath);
-    } catch (error) {
-      process.exitCode = 1;
-      if (error instanceof SpawnFailure) {
-        error.flushOutput("both");
-      }
-      throw error;
-    }
-  });
+    }),
+  );

--- a/packages/host/src/node/cli/hermes.ts
+++ b/packages/host/src/node/cli/hermes.ts
@@ -93,17 +93,12 @@ export const command = new Command("vendor-hermes")
             },
           );
         } catch (error) {
-          if (error instanceof SpawnFailure) {
-            error.flushOutput("both");
-            console.error(
-              `\n🛑 React Native uses the ${hermesVersion} tag and cloning our fork failed.`,
-              `Please see the Node-API package's peer dependency on "react-native" for supported versions.`,
-            );
-            process.exitCode = 1;
-            return;
-          } else {
-            throw error;
-          }
+          throw new UsageError("Failed to clone custom Hermes", {
+            cause: error,
+            fix: {
+              instructions: `Check the network connection and ensure this ${chalk.bold("react-native")} version is supported by ${chalk.bold("react-native-node-api")}.`,
+            },
+          });
         }
       }
       const hermesJsiPath = path.join(hermesPath, "API/jsi/jsi");

--- a/packages/host/src/node/cli/program.ts
+++ b/packages/host/src/node/cli/program.ts
@@ -7,6 +7,7 @@ import {
   chalk,
   SpawnFailure,
   oraPromise,
+  wrapAction,
 } from "@react-native-node-api/cli-utils";
 
 import {
@@ -70,98 +71,102 @@ program
   .option("--android", "Link Android modules")
   .option("--apple", "Link Apple modules")
   .addOption(pathSuffixOption)
-  .action(async (pathArg, { force, prune, pathSuffix, android, apple }) => {
-    console.log("Auto-linking Node-API modules from", chalk.dim(pathArg));
-    const platforms: PlatformName[] = [];
-    if (android) {
-      platforms.push("android");
-    }
-    if (apple) {
-      platforms.push("apple");
-    }
-
-    if (platforms.length === 0) {
-      console.error(
-        `No platform specified, pass one or more of:`,
-        ...PLATFORMS.map((platform) => chalk.bold(`\n  --${platform}`)),
-      );
-      process.exitCode = 1;
-      return;
-    }
-
-    for (const platform of platforms) {
-      const platformDisplayName = getPlatformDisplayName(platform);
-      const platformOutputPath = getAutolinkPath(platform);
-      const modules = await oraPromise(
-        () =>
-          linkModules({
-            platform,
-            fromPath: path.resolve(pathArg),
-            incremental: !force,
-            naming: { pathSuffix },
-            linker: getLinker(platform),
-          }),
-        {
-          text: `Linking ${platformDisplayName} Node-API modules into ${prettyPath(
-            platformOutputPath,
-          )}`,
-          successText: `Linked ${platformDisplayName} Node-API modules into ${prettyPath(
-            platformOutputPath,
-          )}`,
-          failText: (error) =>
-            `Failed to link ${platformDisplayName} Node-API modules into ${prettyPath(
-              platformOutputPath,
-            )}: ${error.message}`,
-        },
-      );
-
-      if (modules.length === 0) {
-        console.log("Found no Node-API modules 🤷");
-      }
-
-      const failures = modules.filter((result) => "failure" in result);
-      const linked = modules.filter((result) => "outputPath" in result);
-
-      for (const { originalPath, outputPath, skipped } of linked) {
-        const prettyOutputPath = outputPath
-          ? "→ " + prettyPath(path.basename(outputPath))
-          : "";
-        if (skipped) {
-          console.log(
-            chalk.greenBright("-"),
-            "Skipped",
-            prettyPath(originalPath),
-            prettyOutputPath,
-            "(up to date)",
-          );
-        } else {
-          console.log(
-            chalk.greenBright("⚭"),
-            "Linked",
-            prettyPath(originalPath),
-            prettyOutputPath,
-          );
+  .action(
+    wrapAction(
+      async (pathArg, { force, prune, pathSuffix, android, apple }) => {
+        console.log("Auto-linking Node-API modules from", chalk.dim(pathArg));
+        const platforms: PlatformName[] = [];
+        if (android) {
+          platforms.push("android");
         }
-      }
+        if (apple) {
+          platforms.push("apple");
+        }
 
-      for (const { originalPath, failure } of failures) {
-        assert(failure instanceof SpawnFailure);
-        console.error(
-          "\n",
-          chalk.redBright("✖"),
-          "Failed to copy",
-          prettyPath(originalPath),
-        );
-        console.error(failure.message);
-        failure.flushOutput("both");
-        process.exitCode = 1;
-      }
+        if (platforms.length === 0) {
+          console.error(
+            `No platform specified, pass one or more of:`,
+            ...PLATFORMS.map((platform) => chalk.bold(`\n  --${platform}`)),
+          );
+          process.exitCode = 1;
+          return;
+        }
 
-      if (prune) {
-        await pruneLinkedModules(platform, modules);
-      }
-    }
-  });
+        for (const platform of platforms) {
+          const platformDisplayName = getPlatformDisplayName(platform);
+          const platformOutputPath = getAutolinkPath(platform);
+          const modules = await oraPromise(
+            () =>
+              linkModules({
+                platform,
+                fromPath: path.resolve(pathArg),
+                incremental: !force,
+                naming: { pathSuffix },
+                linker: getLinker(platform),
+              }),
+            {
+              text: `Linking ${platformDisplayName} Node-API modules into ${prettyPath(
+                platformOutputPath,
+              )}`,
+              successText: `Linked ${platformDisplayName} Node-API modules into ${prettyPath(
+                platformOutputPath,
+              )}`,
+              failText: (error) =>
+                `Failed to link ${platformDisplayName} Node-API modules into ${prettyPath(
+                  platformOutputPath,
+                )}: ${error.message}`,
+            },
+          );
+
+          if (modules.length === 0) {
+            console.log("Found no Node-API modules 🤷");
+          }
+
+          const failures = modules.filter((result) => "failure" in result);
+          const linked = modules.filter((result) => "outputPath" in result);
+
+          for (const { originalPath, outputPath, skipped } of linked) {
+            const prettyOutputPath = outputPath
+              ? "→ " + prettyPath(path.basename(outputPath))
+              : "";
+            if (skipped) {
+              console.log(
+                chalk.greenBright("-"),
+                "Skipped",
+                prettyPath(originalPath),
+                prettyOutputPath,
+                "(up to date)",
+              );
+            } else {
+              console.log(
+                chalk.greenBright("⚭"),
+                "Linked",
+                prettyPath(originalPath),
+                prettyOutputPath,
+              );
+            }
+          }
+
+          for (const { originalPath, failure } of failures) {
+            assert(failure instanceof SpawnFailure);
+            console.error(
+              "\n",
+              chalk.redBright("✖"),
+              "Failed to copy",
+              prettyPath(originalPath),
+            );
+            console.error(failure.message);
+            failure.flushOutput("both");
+            process.exitCode = 1;
+          }
+
+          if (prune) {
+            await pruneLinkedModules(platform, modules);
+          }
+        }
+      },
+    ),
+  );
 
 program
   .command("list")
@@ -169,44 +174,48 @@ program
   .argument("[from-path]", "Some path inside the app package", process.cwd())
   .option("--json", "Output as JSON", false)
   .addOption(pathSuffixOption)
-  .action(async (fromArg, { json, pathSuffix }) => {
-    const rootPath = path.resolve(fromArg);
-    const dependencies = await findNodeApiModulePathsByDependency({
-      fromPath: rootPath,
-      platform: PLATFORMS,
-      includeSelf: true,
-    });
+  .action(
+    wrapAction(async (fromArg, { json, pathSuffix }) => {
+      const rootPath = path.resolve(fromArg);
+      const dependencies = await findNodeApiModulePathsByDependency({
+        fromPath: rootPath,
+        platform: PLATFORMS,
+        includeSelf: true,
+      });
 
-    if (json) {
-      console.log(JSON.stringify(dependencies, null, 2));
-    } else {
-      const dependencyCount = Object.keys(dependencies).length;
-      const xframeworkCount = Object.values(dependencies).reduce(
-        (acc, { modulePaths }) => acc + modulePaths.length,
-        0,
-      );
-      console.log(
-        "Found",
-        chalk.greenBright(xframeworkCount),
-        "Node-API modules in",
-        chalk.greenBright(dependencyCount),
-        dependencyCount === 1 ? "package" : "packages",
-        "from",
-        prettyPath(rootPath),
-      );
-      for (const [dependencyName, dependency] of Object.entries(dependencies)) {
+      if (json) {
+        console.log(JSON.stringify(dependencies, null, 2));
+      } else {
+        const dependencyCount = Object.keys(dependencies).length;
+        const xframeworkCount = Object.values(dependencies).reduce(
+          (acc, { modulePaths }) => acc + modulePaths.length,
+          0,
+        );
         console.log(
-          chalk.blueBright(dependencyName),
-          "→",
-          prettyPath(dependency.path),
+          "Found",
+          chalk.greenBright(xframeworkCount),
+          "Node-API modules in",
+          chalk.greenBright(dependencyCount),
+          dependencyCount === 1 ? "package" : "packages",
+          "from",
+          prettyPath(rootPath),
         );
-        logModulePaths(
-          dependency.modulePaths.map((p) => path.join(dependency.path, p)),
-          { pathSuffix },
-        );
+        for (const [dependencyName, dependency] of Object.entries(
+          dependencies,
+        )) {
+          console.log(
+            chalk.blueBright(dependencyName),
+            "→",
+            prettyPath(dependency.path),
+          );
+          logModulePaths(
+            dependency.modulePaths.map((p) => path.join(dependency.path, p)),
+            { pathSuffix },
+          );
+        }
       }
-    }
-  });
+    }),
+  );
 
 program
   .command("info <path>")
@@ -214,19 +223,21 @@ program
     "Utility to print, module path, the hash of a single Android library",
   )
   .addOption(pathSuffixOption)
-  .action((pathInput, { pathSuffix }) => {
-    const resolvedModulePath = path.resolve(pathInput);
-    const normalizedModulePath = normalizeModulePath(resolvedModulePath);
-    const { packageName, relativePath } =
-      determineModuleContext(resolvedModulePath);
-    const libraryName = getLibraryName(resolvedModulePath, {
-      pathSuffix,
-    });
-    console.log({
-      resolvedModulePath,
-      normalizedModulePath,
-      packageName,
-      relativePath,
-      libraryName,
-    });
-  });
+  .action(
+    wrapAction((pathInput, { pathSuffix }) => {
+      const resolvedModulePath = path.resolve(pathInput);
+      const normalizedModulePath = normalizeModulePath(resolvedModulePath);
+      const { packageName, relativePath } =
+        determineModuleContext(resolvedModulePath);
+      const libraryName = getLibraryName(resolvedModulePath, {
+        pathSuffix,
+      });
+      console.log({
+        resolvedModulePath,
+        normalizedModulePath,
+        packageName,
+        relativePath,
+        libraryName,
+      });
+    }),
+  );


### PR DESCRIPTION
Based on https://github.com/callstackincubator/react-native-node-api/pull/241#discussion_r2363719570 I decided to export a `wrapAction` and call that explicitly instead of monkey-patching commander.