### PR TITLE
Enabled passing `--target` to `cmake --build`

### DIFF
--- a/.changeset/rotten-melons-brush.md
+++ b/.changeset/rotten-melons-brush.md
@@ -1,0 +1,5 @@
+---
+"cmake-rn": minor
+---
+
+Breaking: Renamed --target to --triplet to free up --target for passing CMake targets

--- a/.changeset/swift-loops-create.md
+++ b/.changeset/swift-loops-create.md
@@ -1,0 +1,5 @@
+---
+"cmake-rn": minor
+---
+
+Pass --target to CMake

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -98,7 +98,7 @@ jobs:
       - run: npm ci
       - run: npm run bootstrap
         env:
-          CMAKE_RN_TARGETS: arm64-apple-ios-sim
+          CMAKE_RN_TRIPLETS: arm64-apple-ios-sim
           FERRIC_TARGETS: aarch64-apple-ios-sim
       - run: npm run pod-install
         working-directory: apps/test-app
@@ -129,7 +129,7 @@ jobs:
       - run: npm ci
       - run: npm run bootstrap
         env:
-          CMAKE_RN_TARGETS: i686-linux-android
+          CMAKE_RN_TRIPLETS: i686-linux-android
           FERRIC_TARGETS: i686-linux-android
       - name: Clone patched Hermes version
         shell: bash

--- a/packages/cmake-rn/CHANGELOG.md
+++ b/packages/cmake-rn/CHANGELOG.md
@@ -22,7 +22,7 @@
 
 ### Minor Changes
 
-- 8557768: Derive default targets from the CMAKE_RN_TARGETS environment variable
+- 8557768: Derive default targets from the CMAKE_RN_TRIPLETS environment variable
 
 ### Patch Changes
 

--- a/packages/cmake-rn/src/cli.ts
+++ b/packages/cmake-rn/src/cli.ts
@@ -102,6 +102,11 @@ const defineOption = new Option(
   },
 );
 
+const targetOption = new Option(
+  "--target <target...>",
+  "CMake targets to build",
+).default([] as string[], "Build all targets of the CMake project");
+
 const noAutoLinkOption = new Option(
   "--no-auto-link",
   "Don't mark the output as auto-linkable by react-native-node-api",
@@ -122,6 +127,7 @@ let program = new Command("cmake-rn")
   .addOption(configurationOption)
   .addOption(defineOption)
   .addOption(cleanOption)
+  .addOption(targetOption)
   .addOption(noAutoLinkOption)
   .addOption(noWeakNodeApiLinkageOption);
 
@@ -335,6 +341,7 @@ async function buildProject<T extends string>(
       buildPath,
       "--config",
       configuration,
+      ...(options.target.length > 0 ? ["--target", ...options.target] : []),
       "--",
       ...platform.buildArgs(context, options),
     ],

--- a/packages/cmake-rn/src/platforms.test.ts
+++ b/packages/cmake-rn/src/platforms.test.ts
@@ -3,28 +3,30 @@ import { describe, it } from "node:test";
 
 import {
   platforms,
-  platformHasTarget,
-  findPlatformForTarget,
+  platformHasTriplet,
+  findPlatformForTriplet,
 } from "./platforms.js";
 import { Platform } from "./platforms/types.js";
 
-const mockPlatform = { targets: ["target1", "target2"] } as unknown as Platform;
+const mockPlatform = {
+  triplets: ["triplet1", "triplet2"],
+} as unknown as Platform;
 
-describe("platformHasTarget", () => {
-  it("returns true when platform has target", () => {
-    assert.equal(platformHasTarget(mockPlatform, "target1"), true);
+describe("platformHasTriplet", () => {
+  it("returns true when platform has triplet", () => {
+    assert.equal(platformHasTriplet(mockPlatform, "triplet1"), true);
   });
 
-  it("returns false when platform doesn't have target", () => {
-    assert.equal(platformHasTarget(mockPlatform, "target3"), false);
+  it("returns false when platform doesn't have triplet", () => {
+    assert.equal(platformHasTriplet(mockPlatform, "triplet3"), false);
   });
 });
 
-describe("findPlatformForTarget", () => {
-  it("returns platform when target is found", () => {
+describe("findPlatformForTriplet", () => {
+  it("returns platform when triplet is found", () => {
     assert(platforms.length >= 2, "Expects at least two platforms");
     const [platform1, platform2] = platforms;
-    const platform = findPlatformForTarget(platform1.targets[0]);
+    const platform = findPlatformForTriplet(platform1.triplets[0]);
     assert.equal(platform, platform1);
     assert.notEqual(platform, platform2);
   });

--- a/packages/cmake-rn/src/platforms.ts
+++ b/packages/cmake-rn/src/platforms.ts
@@ -5,23 +5,23 @@ import { platform as apple } from "./platforms/apple.js";
 import { Platform } from "./platforms/types.js";
 
 export const platforms: Platform[] = [android, apple] as const;
-export const allTargets = [...android.targets, ...apple.targets] as const;
+export const allTriplets = [...android.triplets, ...apple.triplets] as const;
 
-export function platformHasTarget<P extends Platform>(
+export function platformHasTriplet<P extends Platform>(
   platform: P,
-  target: unknown,
-): target is P["targets"][number] {
-  return (platform.targets as unknown[]).includes(target);
+  triplet: unknown,
+): triplet is P["triplets"][number] {
+  return (platform.triplets as unknown[]).includes(triplet);
 }
 
-export function findPlatformForTarget(target: unknown) {
+export function findPlatformForTriplet(triplet: unknown) {
   const platform = Object.values(platforms).find((platform) =>
-    platformHasTarget(platform, target),
+    platformHasTriplet(platform, triplet),
   );
   assert(
     platform,
-    `Unable to determine platform from target: ${
-      typeof target === "string" ? target : JSON.stringify(target)
+    `Unable to determine platform from triplet: ${
+      typeof triplet === "string" ? triplet : JSON.stringify(triplet)
     }`,
   );
   return platform;

--- a/packages/cmake-rn/src/platforms/android.ts
+++ b/packages/cmake-rn/src/platforms/android.ts
@@ -6,7 +6,7 @@ import { Option, oraPromise, chalk } from "@react-native-node-api/cli-utils";
 import {
   createAndroidLibsDirectory,
   determineAndroidLibsFilename,
-  AndroidTriplet as Target,
+  AndroidTriplet as Triplet,
 } from "react-native-node-api";
 
 import type { Platform } from "./types.js";
@@ -22,7 +22,7 @@ export const ANDROID_ARCHITECTURES = {
   "aarch64-linux-android": "arm64-v8a",
   "i686-linux-android": "x86",
   "x86_64-linux-android": "x86_64",
-} satisfies Record<Target, AndroidArchitecture>;
+} satisfies Record<Triplet, AndroidArchitecture>;
 
 const ndkVersionOption = new Option(
   "--ndk-version <version>",
@@ -36,16 +36,16 @@ const androidSdkVersionOption = new Option(
 
 type AndroidOpts = { ndkVersion: string; androidSdkVersion: string };
 
-export const platform: Platform<Target[], AndroidOpts> = {
+export const platform: Platform<Triplet[], AndroidOpts> = {
   id: "android",
   name: "Android",
-  targets: [
+  triplets: [
     "aarch64-linux-android",
     "armv7a-linux-androideabi",
     "i686-linux-android",
     "x86_64-linux-android",
   ],
-  defaultTargets() {
+  defaultTriplets() {
     if (process.arch === "arm64") {
       return ["aarch64-linux-android"];
     } else if (process.arch === "x64") {
@@ -59,7 +59,7 @@ export const platform: Platform<Target[], AndroidOpts> = {
       .addOption(ndkVersionOption)
       .addOption(androidSdkVersionOption);
   },
-  configureArgs({ target }, { ndkVersion, androidSdkVersion }) {
+  configureArgs({ triplet }, { ndkVersion, androidSdkVersion }) {
     const { ANDROID_HOME } = process.env;
     assert(
       typeof ANDROID_HOME === "string",
@@ -80,7 +80,7 @@ export const platform: Platform<Target[], AndroidOpts> = {
       ndkPath,
       "build/cmake/android.toolchain.cmake",
     );
-    const architecture = ANDROID_ARCHITECTURES[target];
+    const architecture = ANDROID_ARCHITECTURES[triplet];
 
     return [
       "-G",
@@ -121,11 +121,11 @@ export const platform: Platform<Target[], AndroidOpts> = {
     const { ANDROID_HOME } = process.env;
     return typeof ANDROID_HOME === "string" && fs.existsSync(ANDROID_HOME);
   },
-  async postBuild({ outputPath, targets }, { autoLink }) {
+  async postBuild({ outputPath, triplets }, { autoLink }) {
     // TODO: Include `configuration` in the output path
     const libraryPathByTriplet = Object.fromEntries(
       await Promise.all(
-        targets.map(async ({ target, outputPath }) => {
+        triplets.map(async ({ triplet, outputPath }) => {
           assert(
             fs.existsSync(outputPath),
             `Expected a directory at ${outputPath}`,
@@ -142,10 +142,10 @@ export const platform: Platform<Target[], AndroidOpts> = {
             )
             .map((dirent) => path.join(dirent.parentPath, dirent.name));
           assert.equal(result.length, 1, "Expected exactly one library file");
-          return [target, result[0]] as const;
+          return [triplet, result[0]] as const;
         }),
       ),
-    ) as Record<Target, string>;
+    ) as Record<Triplet, string>;
     const androidLibsFilename = determineAndroidLibsFilename(
       Object.values(libraryPathByTriplet),
     );

--- a/packages/cmake-rn/src/platforms/types.ts
+++ b/packages/cmake-rn/src/platforms/types.ts
@@ -13,16 +13,16 @@ type ExtendedCommand<Opts extends cli.OptionValues> = cli.Command<
   Record<string, unknown> // Global opts are not supported
 >;
 
-export type BaseOpts = Omit<InferOptionValues<typeof program>, "target">;
+export type BaseOpts = Omit<InferOptionValues<typeof program>, "triplet">;
 
-export type TargetContext<Target extends string> = {
-  target: Target;
+export type TripletContext<Triplet extends string> = {
+  triplet: Triplet;
   buildPath: string;
   outputPath: string;
 };
 
 export type Platform<
-  Targets extends string[] = string[],
+  Triplets extends string[] = string[],
   Opts extends cli.OptionValues = Record<string, unknown>,
   Command = ExtendedCommand<Opts>,
 > = {
@@ -35,13 +35,13 @@ export type Platform<
    */
   name: string;
   /**
-   * All the targets supported by this platform.
+   * All the triplets supported by this platform.
    */
-  targets: Readonly<Targets>;
+  triplets: Readonly<Triplets>;
   /**
-   * Get the limited subset of targets that should be built by default for this platform, to support a development workflow.
+   * Get the limited subset of triplets that should be built by default for this platform, to support a development workflow.
    */
-  defaultTargets(): Targets[number][] | Promise<Targets[number][]>;
+  defaultTriplets(): Triplets[number][] | Promise<Triplets[number][]>;
   /**
    * Implement this to add any platform specific options to the command.
    */
@@ -51,21 +51,21 @@ export type Platform<
    */
   isSupportedByHost(): boolean | Promise<boolean>;
   /**
-   * Platform specific arguments passed to CMake to configure a target project.
+   * Platform specific arguments passed to CMake to configure a triplet project.
    */
   configureArgs(
-    context: TargetContext<Targets[number]>,
+    context: TripletContext<Triplets[number]>,
     options: BaseOpts & Opts,
   ): string[];
   /**
-   * Platform specific arguments passed to CMake to build a target project.
+   * Platform specific arguments passed to CMake to build a triplet project.
    */
   buildArgs(
-    context: TargetContext<Targets[number]>,
+    context: TripletContext<Triplets[number]>,
     options: BaseOpts & Opts,
   ): string[];
   /**
-   * Called to combine multiple targets into a single prebuilt artefact.
+   * Called to combine multiple triplets into a single prebuilt artefact.
    */
   postBuild(
     context: {
@@ -73,7 +73,7 @@ export type Platform<
        * Location of the final prebuilt artefact.
        */
       outputPath: string;
-      targets: TargetContext<Targets[number]>[];
+      triplets: TripletContext<Triplets[number]>[];
     },
     options: BaseOpts & Opts,
   ): Promise<void>;


### PR DESCRIPTION
Stacked on https://github.com/callstackincubator/react-native-node-api/pull/243 this enables `cmake-rn` to pass a `--target` through to the `cmake --build` call to allow developers to build a specific target.