### PR TITLE
Check for `REACT_NATIVE_OVERRIDE_HERMES_DIR` earlier

### DIFF
--- a/.changeset/red-candles-sell.md
+++ b/.changeset/red-candles-sell.md
@@ -1,0 +1,5 @@
+---
+"react-native-node-api": patch
+---
+
+Move REACT_NATIVE_OVERRIDE_HERMES_DIR out of tasks to fail earlier

--- a/packages/host/android/build.gradle
+++ b/packages/host/android/build.gradle
@@ -2,6 +2,18 @@ import java.nio.file.Paths
 import groovy.json.JsonSlurper
 import org.gradle.internal.os.OperatingSystem
 
+if (!System.getenv("REACT_NATIVE_OVERRIDE_HERMES_DIR")) {
+    throw new GradleException([
+        "React Native Node-API needs a custom version of Hermes with Node-API enabled.",
+        "Run the following in your terminal, to clone Hermes and instruct React Native to use it:",
+        "",
+        "export REACT_NATIVE_OVERRIDE_HERMES_DIR=\$(npx react-native-node-api vendor-hermes --silent --force)",
+        "",
+        "And follow this guide to build React Native from source:",
+        "https://reactnative.dev/contributing/how-to-build-from-source#update-your-project-to-build-from-source"
+    ].join('\n'))
+}
+
 buildscript {
   ext.getExtOrDefault = {name ->
     return rootProject.ext.has(name) ? rootProject.ext.get(name) : project.properties['NodeApiModules_' + name]
@@ -135,22 +147,6 @@ dependencies {
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 }
 
-task checkHermesOverride {
-    doFirst {
-        if (!System.getenv("REACT_NATIVE_OVERRIDE_HERMES_DIR")) {
-            throw new GradleException([
-                "React Native Node-API needs a custom version of Hermes with Node-API enabled.",
-                "Run the following in your terminal, to clone Hermes and instruct React Native to use it:",
-                "",
-                "export REACT_NATIVE_OVERRIDE_HERMES_DIR=\$(npx react-native-node-api vendor-hermes --silent --force)",
-                "",
-                "And follow this guide to build React Native from source:",
-                "https://reactnative.dev/contributing/how-to-build-from-source#update-your-project-to-build-from-source"
-            ].join('\n'))
-        }
-    }
-}
-
 def commandLinePrefix = OperatingSystem.current().isWindows() ? ["cmd", "/c", "node"] : []
 def cliPath = file("../bin/react-native-node-api.mjs")
 
@@ -169,5 +165,5 @@ task linkNodeApiModules {
   }
 }
 
-preBuild.dependsOn checkHermesOverride, linkNodeApiModules
+preBuild.dependsOn linkNodeApiModules
 

--- a/packages/host/src/node/gradle.test.ts
+++ b/packages/host/src/node/gradle.test.ts
@@ -12,11 +12,11 @@ describe(
   // Skipping these tests by default, as they download a lot and takes a long time
   { skip: process.env.ENABLE_GRADLE_TESTS !== "true" },
   () => {
-    describe("checkHermesOverride task", () => {
+    describe("linkNodeApiModules task", () => {
       it("should fail if REACT_NATIVE_OVERRIDE_HERMES_DIR is not set", () => {
         const { status, stdout, stderr } = cp.spawnSync(
           "sh",
-          ["gradlew", "react-native-node-api:checkHermesOverride"],
+          ["gradlew", "react-native-node-api:linkNodeApiModules"],
           {
             cwd: TEST_APP_ANDROID_PATH,
             env: {
@@ -45,15 +45,18 @@ describe(
           /And follow this guide to build React Native from source/,
         );
       });
-    });
 
-    describe("linkNodeApiModules task", () => {
       it("should call the CLI to autolink", () => {
         const { status, stdout, stderr } = cp.spawnSync(
           "sh",
           ["gradlew", "react-native-node-api:linkNodeApiModules"],
           {
             cwd: TEST_APP_ANDROID_PATH,
+            env: {
+              ...process.env,
+              // We're passing some directory which exists
+              REACT_NATIVE_OVERRIDE_HERMES_DIR: __dirname,
+            },
             encoding: "utf-8",
           },
         );


### PR DESCRIPTION
This is a follow-up to https://github.com/callstackincubator/react-native-node-api/pull/234

Merging this PR will:
- Move `REACT_NATIVE_OVERRIDE_HERMES_DIR` out of tasks to fail earlier.
