### PR TITLE
Use CMake file API to read shared library target paths

### DIFF
--- a/.changeset/evil-vans-love.md
+++ b/.changeset/evil-vans-love.md
@@ -1,0 +1,5 @@
+---
+"cmake-rn": patch
+---
+
+Use CMake file API to read shared library target paths

--- a/package-lock.json
+++ b/package-lock.json
@@ -14808,6 +14808,7 @@
       "version": "0.4.0",
       "dependencies": {
         "@react-native-node-api/cli-utils": "0.1.0",
+        "cmake-file-api": "0.1.0",
         "react-native-node-api": "0.5.1"
       },
       "bin": {

--- a/packages/cmake-rn/package.json
+++ b/packages/cmake-rn/package.json
@@ -23,6 +23,7 @@
   },
   "dependencies": {
     "@react-native-node-api/cli-utils": "0.1.0",
+    "cmake-file-api": "0.1.0",
     "react-native-node-api": "0.5.1"
   },
   "peerDependencies": {

--- a/packages/cmake-rn/src/cli.ts
+++ b/packages/cmake-rn/src/cli.ts
@@ -13,6 +13,7 @@ import {
   wrapAction,
 } from "@react-native-node-api/cli-utils";
 import { isSupportedTriplet } from "react-native-node-api";
+import * as cmakeFileApi from "cmake-file-api";
 
 import {
   getCmakeJSVariables,
@@ -326,6 +327,8 @@ async function configureProject<T extends string>(
     ...options.define,
     { CMAKE_LIBRARY_OUTPUT_DIRECTORY: outputPath },
   ];
+
+  await cmakeFileApi.createSharedStatelessQuery(buildPath, "codemodel", "2");
 
   await spawn(
     "cmake",

--- a/packages/cmake-rn/src/platforms/android.ts
+++ b/packages/cmake-rn/src/platforms/android.ts
@@ -5,7 +5,6 @@ import path from "node:path";
 import { Option, oraPromise, chalk } from "@react-native-node-api/cli-utils";
 import {
   createAndroidLibsDirectory,
-  determineAndroidLibsFilename,
   AndroidTriplet as Triplet,
 } from "react-native-node-api";
 import * as cmakeFileApi from "cmake-file-api";
@@ -123,56 +122,59 @@ export const platform: Platform<Triplet[], AndroidOpts> = {
     return typeof ANDROID_HOME === "string" && fs.existsSync(ANDROID_HOME);
   },
   async postBuild({ outputPath, triplets }, { autoLink, configuration }) {
-    const libraryPathByTriplet = Object.fromEntries(
-      await Promise.all(
-        triplets.map(async ({ triplet, buildPath }) => {
-          assert(
-            fs.existsSync(buildPath),
-            `Expected a directory at ${buildPath}`,
-          );
-          const targets = await cmakeFileApi.readCurrentTargetsDeep(
-            buildPath,
-            configuration,
-            "2.0",
-          );
-          const sharedLibraries = targets.filter(
-            (target) => target.type === "SHARED_LIBRARY",
-          );
-          assert.equal(
-            sharedLibraries.length,
-            1,
-            "Expected exactly one shared library",
-          );
-          const [sharedLibrary] = sharedLibraries;
-          const { artifacts } = sharedLibrary;
-          assert(
-            artifacts && artifacts.length,
-            "Expected exactly one artifact",
-          );
-          const [artifact] = artifacts;
-          return [triplet, path.join(buildPath, artifact.path)] as const;
-        }),
-      ),
-    ) as Record<Triplet, string>;
-    const androidLibsFilename = determineAndroidLibsFilename(
-      Object.values(libraryPathByTriplet),
-    );
-    const androidLibsOutputPath = path.resolve(outputPath, androidLibsFilename);
+    const prebuilds: Record<string, Partial<Record<Triplet, string>>> = {};
 
-    await oraPromise(
-      createAndroidLibsDirectory({
-        outputPath: androidLibsOutputPath,
-        libraryPathByTriplet,
-        autoLink,
-      }),
-      {
-        text: "Assembling Android libs directory",
-        successText: `Android libs directory assembled into ${chalk.dim(
-          path.relative(process.cwd(), androidLibsOutputPath),
-        )}`,
-        failText: ({ message }) =>
-          `Failed to assemble Android libs directory: ${message}`,
-      },
-    );
+    for (const { triplet, buildPath } of triplets) {
+      assert(fs.existsSync(buildPath), `Expected a directory at ${buildPath}`);
+      const targets = await cmakeFileApi.readCurrentTargetsDeep(
+        buildPath,
+        configuration,
+        "2.0",
+      );
+      const sharedLibraries = targets.filter(
+        (target) => target.type === "SHARED_LIBRARY",
+      );
+      assert.equal(
+        sharedLibraries.length,
+        1,
+        "Expected exactly one shared library",
+      );
+      const [sharedLibrary] = sharedLibraries;
+      const { artifacts } = sharedLibrary;
+      assert(artifacts && artifacts.length, "Expected exactly one artifact");
+      const [artifact] = artifacts;
+      // Add prebuild entry, creating a new entry if needed
+      if (!(sharedLibrary.name in prebuilds)) {
+        prebuilds[sharedLibrary.name] = {};
+      }
+      prebuilds[sharedLibrary.name][triplet] = path.join(
+        buildPath,
+        artifact.path,
+      );
+    }
+
+    for (const [libraryName, libraryPathByTriplet] of Object.entries(
+      prebuilds,
+    )) {
+      const prebuildOutputPath = path.resolve(
+        outputPath,
+        `${libraryName}.android.node`,
+      );
+      await oraPromise(
+        createAndroidLibsDirectory({
+          outputPath: prebuildOutputPath,
+          libraryPathByTriplet,
+          autoLink,
+        }),
+        {
+          text: `Assembling Android libs directory (${libraryName})`,
+          successText: `Android libs directory (${libraryName}) assembled into ${chalk.dim(
+            path.relative(process.cwd(), prebuildOutputPath),
+          )}`,
+          failText: ({ message }) =>
+            `Failed to assemble Android libs directory (${libraryName}): ${message}`,
+        },
+      );
+    }
   },
 };

--- a/packages/cmake-rn/src/platforms/android.ts
+++ b/packages/cmake-rn/src/platforms/android.ts
@@ -141,7 +141,10 @@ export const platform: Platform<Triplet[], AndroidOpts> = {
       );
       const [sharedLibrary] = sharedLibraries;
       const { artifacts } = sharedLibrary;
-      assert(artifacts && artifacts.length, "Expected exactly one artifact");
+      assert(
+        artifacts && artifacts.length === 1,
+        "Expected exactly one artifact",
+      );
       const [artifact] = artifacts;
       // Add prebuild entry, creating a new entry if needed
       if (!(sharedLibrary.name in prebuilds)) {

--- a/packages/cmake-rn/src/platforms/apple.ts
+++ b/packages/cmake-rn/src/platforms/apple.ts
@@ -153,7 +153,10 @@ export const platform: Platform<Triplet[], AppleOpts> = {
       );
       const [sharedLibrary] = sharedLibraries;
       const { artifacts } = sharedLibrary;
-      assert(artifacts && artifacts.length, "Expected exactly one artifact");
+      assert(
+        artifacts && artifacts.length === 1,
+        "Expected exactly one artifact",
+      );
       const [artifact] = artifacts;
       // Add prebuild entry, creating a new entry if needed
       if (!(sharedLibrary.name in prebuilds)) {

--- a/packages/ferric/src/build.ts
+++ b/packages/ferric/src/build.ts
@@ -204,15 +204,13 @@ export const buildCommand = new Command("build")
         );
 
         if (androidLibraries.length > 0) {
-          const libraryPathByTriplet = Object.fromEntries(
-            androidLibraries.map(([target, outputPath]) => [
-              ANDROID_TRIPLET_PER_TARGET[target],
-              outputPath,
-            ]),
-          ) as Record<AndroidTriplet, string>;
+          const libraries = androidLibraries.map(([target, outputPath]) => ({
+            triplet: ANDROID_TRIPLET_PER_TARGET[target],
+            libraryPath: outputPath,
+          }));
 
           const androidLibsFilename = determineAndroidLibsFilename(
-            Object.values(libraryPathByTriplet),
+            libraries.map(({ libraryPath }) => libraryPath),
           );
           const androidLibsOutputPath = path.resolve(
             outputPath,
@@ -222,7 +220,7 @@ export const buildCommand = new Command("build")
           await oraPromise(
             createAndroidLibsDirectory({
               outputPath: androidLibsOutputPath,
-              libraryPathByTriplet,
+              libraries,
               autoLink: true,
             }),
             {

--- a/packages/ferric/src/build.ts
+++ b/packages/ferric/src/build.ts
@@ -238,7 +238,9 @@ export const buildCommand = new Command("build")
 
         if (appleLibraries.length > 0) {
           const libraryPaths = await combineLibraries(appleLibraries);
-          const frameworkPaths = libraryPaths.map(createAppleFramework);
+          const frameworkPaths = await Promise.all(
+            libraryPaths.map(createAppleFramework),
+          );
           const xcframeworkFilename = determineXCFrameworkFilename(
             frameworkPaths,
             xcframeworkExtension ? ".xcframework" : ".apple.node",

--- a/packages/host/src/node/prebuilds/android.ts
+++ b/packages/host/src/node/prebuilds/android.ts
@@ -32,24 +32,24 @@ export function determineAndroidLibsFilename(libraryPaths: string[]) {
 
 type AndroidLibsDirectoryOptions = {
   outputPath: string;
-  libraryPathByTriplet: Partial<Record<AndroidTriplet, string>>;
+  libraries: { triplet: AndroidTriplet; libraryPath: string }[];
   autoLink: boolean;
 };
 
 export async function createAndroidLibsDirectory({
   outputPath,
-  libraryPathByTriplet,
+  libraries,
   autoLink,
 }: AndroidLibsDirectoryOptions) {
   // Delete and recreate any existing output directory
   await fs.promises.rm(outputPath, { recursive: true, force: true });
   await fs.promises.mkdir(outputPath, { recursive: true });
-  for (const [triplet, libraryPath] of Object.entries(libraryPathByTriplet)) {
+  for (const { triplet, libraryPath } of libraries) {
     assert(
       fs.existsSync(libraryPath),
       `Library not found: ${libraryPath} for triplet ${triplet}`,
     );
-    const arch = ANDROID_ARCHITECTURES[triplet as AndroidTriplet];
+    const arch = ANDROID_ARCHITECTURES[triplet];
     const archOutputPath = path.join(outputPath, arch);
     await fs.promises.mkdir(archOutputPath, { recursive: true });
     // Strip the ".node" extension from the library name

--- a/packages/host/src/node/prebuilds/android.ts
+++ b/packages/host/src/node/prebuilds/android.ts
@@ -32,7 +32,7 @@ export function determineAndroidLibsFilename(libraryPaths: string[]) {
 
 type AndroidLibsDirectoryOptions = {
   outputPath: string;
-  libraryPathByTriplet: Record<AndroidTriplet, string>;
+  libraryPathByTriplet: Partial<Record<AndroidTriplet, string>>;
   autoLink: boolean;
 };
 

--- a/packages/host/src/node/prebuilds/apple.ts
+++ b/packages/host/src/node/prebuilds/apple.ts
@@ -2,7 +2,6 @@ import assert from "node:assert/strict";
 import fs from "node:fs";
 import path from "node:path";
 import os from "node:os";
-import cp from "node:child_process";
 
 import { spawn } from "@react-native-node-api/cli-utils";
 
@@ -77,12 +76,13 @@ export async function createAppleFramework(libraryPath: string) {
   // TODO: Consider copying the library instead of renaming it
   await fs.promises.rename(libraryPath, newLibraryPath);
   // Update the name of the library
-  // TODO: Make this call async
-  cp.spawnSync("install_name_tool", [
-    "-id",
-    `@rpath/${libraryName}.framework/${libraryName}`,
-    newLibraryPath,
-  ]);
+  await spawn(
+    "install_name_tool",
+    ["-id", `@rpath/${libraryName}.framework/${libraryName}`, newLibraryPath],
+    {
+      outputMode: "buffered",
+    },
+  );
   return frameworkPath;
 }
 

--- a/packages/host/src/node/prebuilds/apple.ts
+++ b/packages/host/src/node/prebuilds/apple.ts
@@ -45,7 +45,7 @@ type XCframeworkOptions = {
   autoLink: boolean;
 };
 
-export function createAppleFramework(libraryPath: string) {
+export async function createAppleFramework(libraryPath: string) {
   assert(fs.existsSync(libraryPath), `Library not found: ${libraryPath}`);
   // Write a info.plist file to the framework
   const libraryName = path.basename(libraryPath, path.extname(libraryPath));
@@ -54,11 +54,11 @@ export function createAppleFramework(libraryPath: string) {
     `${libraryName}.framework`,
   );
   // Create the framework from scratch
-  fs.rmSync(frameworkPath, { recursive: true, force: true });
-  fs.mkdirSync(frameworkPath);
-  fs.mkdirSync(path.join(frameworkPath, "Headers"));
+  await fs.promises.rm(frameworkPath, { recursive: true, force: true });
+  await fs.promises.mkdir(frameworkPath);
+  await fs.promises.mkdir(path.join(frameworkPath, "Headers"));
   // Create an empty Info.plist file
-  fs.writeFileSync(
+  await fs.promises.writeFile(
     path.join(frameworkPath, "Info.plist"),
     createPlistContent({
       CFBundleDevelopmentRegion: "en",
@@ -75,8 +75,9 @@ export function createAppleFramework(libraryPath: string) {
   );
   const newLibraryPath = path.join(frameworkPath, libraryName);
   // TODO: Consider copying the library instead of renaming it
-  fs.renameSync(libraryPath, newLibraryPath);
+  await fs.promises.rename(libraryPath, newLibraryPath);
   // Update the name of the library
+  // TODO: Make this call async
   cp.spawnSync("install_name_tool", [
     "-id",
     `@rpath/${libraryName}.framework/${libraryName}`,


### PR DESCRIPTION
This PR is stacked on #257 and fixes #253 by introducing use of the [CMake file API](https://cmake.org/cmake/help/latest/manual/cmake-file-api.7.html) to read shared library target paths.

Merging this PR will:
- Implement at wrapper around the CMake file API to query and read metadata for targets in the build directories, instead of relying on pre-defined locations.
- Fix #201 by leaning on the CMake structure to group shared library artifacts.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches artifact discovery to the CMake File API and updates Android/Apple post-build flows and host helpers to assemble outputs per-target using the new APIs.
> 
> - **cmake-rn**:
>   - Use `cmake-file-api`: add dependency and initialize query (`codemodel` v2) in `src/cli.ts`.
>   - Android `postBuild`: read targets via CMake File API, group shared libraries by target, and assemble per-library `.android.node` outputs using updated host API; include `configuration`.
>   - Apple `postBuild`: read targets via CMake File API, generate frameworks and assemble per-library XCFrameworks (or `.apple.node`).
> - **host (prebuild helpers)**:
>   - Android: change `createAndroidLibsDirectory` signature to `libraries: { triplet, libraryPath }[]`; adjust implementation.
>   - Apple: make `createAppleFramework` async and use `spawn`/`fs.promises`.
> - **ferric**:
>   - Adapt to new Android helper signature and await async `createAppleFramework` when building XCFrameworks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4d0b7dfbd68a454453b542f955e5e39289695639. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->