### PR TITLE
Filter CMake targets by target name when passed

### DIFF
--- a/.changeset/cold-showers-arrive.md
+++ b/.changeset/cold-showers-arrive.md
@@ -1,0 +1,5 @@
+---
+"cmake-rn": patch
+---
+
+Filter CMake targets by target name when passed

--- a/packages/cmake-rn/src/platforms/android.ts
+++ b/packages/cmake-rn/src/platforms/android.ts
@@ -121,7 +121,10 @@ export const platform: Platform<Triplet[], AndroidOpts> = {
     const { ANDROID_HOME } = process.env;
     return typeof ANDROID_HOME === "string" && fs.existsSync(ANDROID_HOME);
   },
-  async postBuild({ outputPath, triplets }, { autoLink, configuration }) {
+  async postBuild(
+    { outputPath, triplets },
+    { autoLink, configuration, target },
+  ) {
     const prebuilds: Record<
       string,
       { triplet: Triplet; libraryPath: string }[]
@@ -135,7 +138,9 @@ export const platform: Platform<Triplet[], AndroidOpts> = {
         "2.0",
       );
       const sharedLibraries = targets.filter(
-        (target) => target.type === "SHARED_LIBRARY",
+        ({ type, name }) =>
+          type === "SHARED_LIBRARY" &&
+          (target.length === 0 || target.includes(name)),
       );
       assert.equal(
         sharedLibraries.length,

--- a/packages/cmake-rn/src/platforms/apple.ts
+++ b/packages/cmake-rn/src/platforms/apple.ts
@@ -133,7 +133,7 @@ export const platform: Platform<Triplet[], AppleOpts> = {
   },
   async postBuild(
     { outputPath, triplets },
-    { configuration, autoLink, xcframeworkExtension },
+    { configuration, autoLink, xcframeworkExtension, target },
   ) {
     const prebuilds: Record<string, string[]> = {};
     for (const { buildPath } of triplets) {
@@ -144,7 +144,9 @@ export const platform: Platform<Triplet[], AppleOpts> = {
         "2.0",
       );
       const sharedLibraries = targets.filter(
-        (target) => target.type === "SHARED_LIBRARY",
+        ({ type, name }) =>
+          type === "SHARED_LIBRARY" &&
+          (target.length === 0 || target.includes(name)),
       );
       assert.equal(
         sharedLibraries.length,


### PR DESCRIPTION
Instead of simply filtering by shared libraries, we should filter by the `--target` value passed to `cmake-rn` to allow callers to pick the right shared object in CMake projects building outputting multiple.

Merging this PR will:
- Use a non-empty array of target names to filter shared libraries in the platform specific `postBuild` functions.
