### PR TITLE
Fix `requireNodeAddon` return type

### DIFF
--- a/.changeset/bumpy-things-poke.md
+++ b/.changeset/bumpy-things-poke.md
@@ -1,0 +1,5 @@
+---
+"react-native-node-api": patch
+---
+
+Fix requireNodeAddon return type

--- a/packages/host/src/react-native/NativeNodeApiHost.ts
+++ b/packages/host/src/react-native/NativeNodeApiHost.ts
@@ -1,8 +1,0 @@
-import type { TurboModule } from "react-native";
-import { TurboModuleRegistry } from "react-native";
-
-export interface Spec extends TurboModule {
-  requireNodeAddon(libraryName: string): void;
-}
-
-export default TurboModuleRegistry.getEnforcing<Spec>("NodeApiHost");

--- a/packages/host/src/react-native/index.ts
+++ b/packages/host/src/react-native/index.ts
@@ -1,3 +1,14 @@
-import native from "./NativeNodeApiHost";
+import { type TurboModule, TurboModuleRegistry } from "react-native";
 
-export const requireNodeAddon = native.requireNodeAddon.bind(native);
+export interface Spec extends TurboModule {
+  requireNodeAddon<T = unknown>(libraryName: string): T;
+}
+
+const native = TurboModuleRegistry.getEnforcing<Spec>("NodeApiHost");
+
+/**
+ * Loads a native Node-API addon by filename.
+ */
+export function requireNodeAddon<T = unknown>(libraryName: string): T {
+  return native.requireNodeAddon<T>(libraryName);
+}


### PR DESCRIPTION
Merging this PR will fix #265 by:
- Refactor host package's react native entrypoint to have its `requireNodeAddon` function return a generic type `T` (defaulting to `unknown`).