### PR TITLE
Add apple folder to npm

### DIFF
--- a/packages/host/package.json
+++ b/packages/host/package.json
@@ -32,7 +32,7 @@
     "android",
     "!android/.cxx",
     "!android/build",
-    "ios",
+    "apple",
     "include",
     "babel-plugin.js",
     "scripts/patch-hermes.rb",


### PR DESCRIPTION
# Issue
One of the previous [commit](https://github.com/callstackincubator/react-native-node-api/commit/c6986981ed9cf66d65b58bb7db6dbd736ccb6449) for 0.6.2 contains changes to the file system, namely `Moved "ios" into a shared "apple" directory`
but the changes in package.json weren't made.

# Things done
- replaced in package.json `ios` to `apple` in `files`



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates `packages/host/package.json` to publish the `apple` directory instead of `ios`.
> 
> - **Packaging**:
>   - Update `packages/host/package.json` `files` array: replace `ios` with `apple` so the `apple` directory is included in the published package.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 291f9a7ec20dca34f2639c828b634a28be30c0af. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->