### PR TITLE
Remove `--force` from vendor hermes command

### DIFF
--- a/.changeset/tender-laws-admire.md
+++ b/.changeset/tender-laws-admire.md
@@ -1,0 +1,5 @@
+---
+"react-native-node-api": patch
+---
+
+Don't instruct users to pass --force when vendoring hermes

--- a/packages/host/android/build.gradle
+++ b/packages/host/android/build.gradle
@@ -7,7 +7,7 @@ if (!System.getenv("REACT_NATIVE_OVERRIDE_HERMES_DIR")) {
         "React Native Node-API needs a custom version of Hermes with Node-API enabled.",
         "Run the following in your Bash- or Zsh-compatible terminal, to clone Hermes and instruct React Native to use it:",
         "",
-        "export REACT_NATIVE_OVERRIDE_HERMES_DIR=\$(npx react-native-node-api vendor-hermes --silent --force)",
+        "export REACT_NATIVE_OVERRIDE_HERMES_DIR=\$(npx react-native-node-api vendor-hermes --silent)",
         "",
         "And follow this guide to build React Native from source:",
         "https://reactnative.dev/contributing/how-to-build-from-source#update-your-project-to-build-from-source"

--- a/packages/host/src/node/gradle.test.ts
+++ b/packages/host/src/node/gradle.test.ts
@@ -38,7 +38,7 @@ describe(
         );
         assert.match(
           stderr,
-          /export REACT_NATIVE_OVERRIDE_HERMES_DIR=\$\(npx react-native-node-api vendor-hermes --silent --force\)/,
+          /export REACT_NATIVE_OVERRIDE_HERMES_DIR=\$\(npx react-native-node-api vendor-hermes --silent\)/,
         );
         assert.match(
           stderr,


### PR DESCRIPTION
It seemed wrong to me that we're asking users to `--force` when vendoring Hermes. This will be slower and is not needed in most cases.