### PR TITLE
Fix escaping "_" in bundle identifiers when `gyp-to-cmake` generates projects

### DIFF
--- a/.changeset/tall-tips-fail.md
+++ b/.changeset/tall-tips-fail.md
@@ -1,0 +1,5 @@
+---
+"gyp-to-cmake": patch
+---
+
+Fixed escaping bundle ids to no longer contain "\_"

--- a/packages/gyp-to-cmake/src/transformer.ts
+++ b/packages/gyp-to-cmake/src/transformer.ts
@@ -27,8 +27,12 @@ function escapeSpaces(source: string) {
   return source.replace(/ /g, "\\ ");
 }
 
-function escapeBundleIdentifier(identifier: string) {
-  return identifier.replaceAll("__", ".").replace(/[^A-Za-z0-9.-_]/g, "-");
+/**
+ * Escapes any input to match a CFBundleIdentifier
+ * See https://developer.apple.com/documentation/bundleresources/information-property-list/cfbundleidentifier
+ */
+export function escapeBundleIdentifier(input: string) {
+  return input.replaceAll("__", ".").replace(/[^A-Za-z0-9-.]/g, "-");
 }
 
 /**


### PR DESCRIPTION
Noticed the gyp-to-cmake was not escaping bundle ids correctly and I have no idea why that worked in the past 🙄