### PR TITLE
Bump "node-addon-examples" to remove clang-format entirely

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7937,14 +7937,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/clang-format": {
-      "name": "dry-uninstall",
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/dry-uninstall/-/dry-uninstall-0.3.0.tgz",
-      "integrity": "sha512-b8h94RVpETWkVV59x62NsY++79bM7Si6Dxq7a4iVxRcJU3ZJJ4vaiC7wUZwM8WDK0ySRL+i+T/1SMAzbJLejYA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/cli-cursor": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
@@ -12183,12 +12175,11 @@
     },
     "node_modules/node-addon-examples": {
       "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/nodejs/node-addon-examples.git#4213d4c9d07996ae68629c67926251e117f8e52a",
-      "integrity": "sha512-4HfGZCsD1IwOx213KjizaXTgEFb7+sXi3dtlay1kERtHRnXMeTsMzruRrSQmm5f1QkVqK3sZPawc1+EW135s4Q==",
+      "resolved": "git+ssh://git@github.com/nodejs/node-addon-examples.git#4b7dd86a85644610e6de80154df9acac9329b509",
+      "integrity": "sha512-9bQgZbEIjN7umKgCT4z8781K8h+2EtAaMgXhByll8arccTjSTGyO8ipUngV14ieo58cf89ghM3Jh7quXL1vUwA==",
       "dev": true,
       "dependencies": {
         "chalk": "^5.4.1",
-        "clang-format": "^1.4.0",
         "cmake-js": "^7.1.1",
         "semver": "^7.1.3"
       }
@@ -15391,7 +15382,7 @@
       "devDependencies": {
         "cmake-rn": "*",
         "gyp-to-cmake": "*",
-        "node-addon-examples": "github:nodejs/node-addon-examples#4213d4c9d07996ae68629c67926251e117f8e52a",
+        "node-addon-examples": "github:nodejs/node-addon-examples#4b7dd86a85644610e6de80154df9acac9329b509",
         "read-pkg": "^9.0.1"
       }
     },

--- a/package.json
+++ b/package.json
@@ -76,9 +76,6 @@
     "typescript": "^5.8.0",
     "typescript-eslint": "^8.38.0"
   },
-  "overrides": {
-    "clang-format": "npm:dry-uninstall"
-  },
   "devEngines": {
     "runtime": {
       "name": "node",

--- a/packages/node-addon-examples/package.json
+++ b/packages/node-addon-examples/package.json
@@ -30,7 +30,7 @@
   },
   "devDependencies": {
     "cmake-rn": "*",
-    "node-addon-examples": "github:nodejs/node-addon-examples#4213d4c9d07996ae68629c67926251e117f8e52a",
+    "node-addon-examples": "github:nodejs/node-addon-examples#4b7dd86a85644610e6de80154df9acac9329b509",
     "gyp-to-cmake": "*",
     "read-pkg": "^9.0.1"
   },


### PR DESCRIPTION
With https://github.com/nodejs/node-addon-examples/pull/616 merged we can bump the version of `node-addon-examples` and remove the override.