### PR TITLE
Apple link without cocoapods

### DIFF
--- a/.changeset/social-peaches-end.md
+++ b/.changeset/social-peaches-end.md
@@ -1,0 +1,5 @@
+---
+"react-native-node-api": minor
+---
+
+Modify Xcode project to add a build phase to the main project app to link Node-API frameworks directly

--- a/package-lock.json
+++ b/package-lock.json
@@ -1946,6 +1946,56 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@bacons/xcode": {
+      "version": "1.0.0-alpha.29",
+      "resolved": "https://registry.npmjs.org/@bacons/xcode/-/xcode-1.0.0-alpha.29.tgz",
+      "integrity": "sha512-b2P+Y6ovdlie3A8Tx6QBFlbfQPhXe0vDS83W0DVob6732e3TukgVMbVcE9umn36BaeGzmJVjMFtqEyhWetjRWg==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/plist": "^0.0.18",
+        "debug": "^4.3.4",
+        "uuid": "^8.3.2"
+      }
+    },
+    "node_modules/@bacons/xcode/node_modules/@expo/plist": {
+      "version": "0.0.18",
+      "resolved": "https://registry.npmjs.org/@expo/plist/-/plist-0.0.18.tgz",
+      "integrity": "sha512-+48gRqUiz65R21CZ/IXa7RNBXgAI/uPSdvJqoN9x1hfL44DNbUoWHgHiEXTx7XelcATpDwNTz6sHLfy0iNqf+w==",
+      "license": "MIT",
+      "dependencies": {
+        "@xmldom/xmldom": "~0.7.0",
+        "base64-js": "^1.2.3",
+        "xmlbuilder": "^14.0.0"
+      }
+    },
+    "node_modules/@bacons/xcode/node_modules/@xmldom/xmldom": {
+      "version": "0.7.13",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.7.13.tgz",
+      "integrity": "sha512-lm2GW5PkosIzccsaZIz7tp8cPADSIlIHWDFTR1N0SzfinhhYgeIQjFMz4rYzanCScr3DqQLeomUDArp6MWKm+g==",
+      "deprecated": "this version is no longer supported, please update to at least 0.8.*",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/@bacons/xcode/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/@bacons/xcode/node_modules/xmlbuilder": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-14.0.0.tgz",
+      "integrity": "sha512-ts+B2rSe4fIckR6iquDjsKbQFK2NlUk6iG5nf14mDEyldgoc2nEKZ3jZWMPTxGQwVgToSjt6VGIho1H8/fNFTg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
     "node_modules/@changesets/apply-release-plan": {
       "version": "7.0.13",
       "resolved": "https://registry.npmjs.org/@changesets/apply-release-plan/-/apply-release-plan-7.0.13.tgz",
@@ -15353,8 +15403,10 @@
       "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
+        "@bacons/xcode": "^1.0.0-alpha.29",
         "@expo/plist": "^0.4.7",
         "@react-native-node-api/cli-utils": "0.1.4",
+        "@xmldom/xmldom": "^0.8.11",
         "pkg-dir": "^8.0.0",
         "read-pkg": "^9.0.1",
         "zod": "^4.1.11"

--- a/packages/host/package.json
+++ b/packages/host/package.json
@@ -35,6 +35,7 @@
     "include",
     "babel-plugin.js",
     "scripts/patch-hermes.rb",
+    "scripts/patch-xcode-project.rb",
     "weak-node-api/**",
     "!weak-node-api/build/",
     "*.js",
@@ -67,7 +68,9 @@
   ],
   "license": "MIT",
   "dependencies": {
+    "@bacons/xcode": "^1.0.0-alpha.29",
     "@expo/plist": "^0.4.7",
+    "@xmldom/xmldom": "^0.8.11",
     "@react-native-node-api/cli-utils": "0.1.4",
     "pkg-dir": "^8.0.0",
     "read-pkg": "^9.0.1",

--- a/packages/host/scripts/patch-xcode-project.rb
+++ b/packages/host/scripts/patch-xcode-project.rb
@@ -1,0 +1,13 @@
+unless defined?(@exit_hooks_installed)
+  # Setting a flag to avoid running this command on every require
+  @exit_hooks_installed = true
+
+  NODE_PATH ||= `which node`.strip
+  CLI_COMMAND ||= "'#{NODE_PATH}' '#{File.join(__dir__, "../dist/node/cli/run.js")}'"
+  PATCH_XCODE_PROJECT_COMMAND ||= "#{CLI_COMMAND} patch-xcode-project '#{Pod::Config.instance.installation_root}'"
+  
+  # Using an at_exit hook to ensure the command is executed after the pod install is complete
+  at_exit do
+    system(PATCH_XCODE_PROJECT_COMMAND) or raise "Failed to patch the Xcode project"
+  end
+end

--- a/packages/host/scripts/patch-xcode-project.rb
+++ b/packages/host/scripts/patch-xcode-project.rb
@@ -2,9 +2,9 @@ unless defined?(@exit_hooks_installed)
   # Setting a flag to avoid running this command on every require
   @exit_hooks_installed = true
 
-  NODE_BINARY ||= ENV["NODE_BINARY"] || `command -v node`.strip
-  CLI_COMMAND ||= "'#{NODE_BINARY}' '#{File.join(__dir__, "../dist/node/cli/run.js")}'"
-  PATCH_XCODE_PROJECT_COMMAND ||= "#{CLI_COMMAND} patch-xcode-project '#{Pod::Config.instance.installation_root}'"
+  NODE_BINARY = ENV["NODE_BINARY"] || `command -v node`.strip
+  CLI_COMMAND = "'#{NODE_BINARY}' '#{File.join(__dir__, "../dist/node/cli/run.js")}'"
+  PATCH_XCODE_PROJECT_COMMAND = "#{CLI_COMMAND} patch-xcode-project '#{Pod::Config.instance.installation_root}'"
   
   # Using an at_exit hook to ensure the command is executed after the pod install is complete
   at_exit do

--- a/packages/host/scripts/patch-xcode-project.rb
+++ b/packages/host/scripts/patch-xcode-project.rb
@@ -2,8 +2,8 @@ unless defined?(@exit_hooks_installed)
   # Setting a flag to avoid running this command on every require
   @exit_hooks_installed = true
 
-  NODE_PATH ||= `which node`.strip
-  CLI_COMMAND ||= "'#{NODE_PATH}' '#{File.join(__dir__, "../dist/node/cli/run.js")}'"
+  NODE_BINARY ||= ENV["NODE_BINARY"] || `command -v node`.strip
+  CLI_COMMAND ||= "'#{NODE_BINARY}' '#{File.join(__dir__, "../dist/node/cli/run.js")}'"
   PATCH_XCODE_PROJECT_COMMAND ||= "#{CLI_COMMAND} patch-xcode-project '#{Pod::Config.instance.installation_root}'"
   
   # Using an at_exit hook to ensure the command is executed after the pod install is complete

--- a/packages/host/src/node/cli/android.ts
+++ b/packages/host/src/node/cli/android.ts
@@ -19,10 +19,9 @@ const ANDROID_ARCHITECTURES = [
 export async function linkAndroidDir({
   modulePath,
   naming,
-  platform,
 }: LinkModuleOptions): Promise<LinkModuleResult> {
   const libraryName = getLibraryName(modulePath, naming);
-  const outputPath = getLinkedModuleOutputPath(platform, modulePath, naming);
+  const outputPath = getLinkedModuleOutputPath("android", modulePath, naming);
 
   await fs.promises.rm(outputPath, { recursive: true, force: true });
   await fs.promises.cp(modulePath, outputPath, { recursive: true });

--- a/packages/host/src/node/cli/android.ts
+++ b/packages/host/src/node/cli/android.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import fs from "node:fs";
 import path from "node:path";
 
-import { getLatestMtime, getLibraryName, MAGIC_FILENAME } from "../path-utils";
+import { getLibraryName, MAGIC_FILENAME } from "../path-utils";
 import {
   getLinkedModuleOutputPath,
   LinkModuleResult,
@@ -17,26 +17,12 @@ const ANDROID_ARCHITECTURES = [
 ] as const;
 
 export async function linkAndroidDir({
-  incremental,
   modulePath,
   naming,
   platform,
 }: LinkModuleOptions): Promise<LinkModuleResult> {
   const libraryName = getLibraryName(modulePath, naming);
   const outputPath = getLinkedModuleOutputPath(platform, modulePath, naming);
-
-  if (incremental && fs.existsSync(outputPath)) {
-    const moduleModified = getLatestMtime(modulePath);
-    const outputModified = getLatestMtime(outputPath);
-    if (moduleModified < outputModified) {
-      return {
-        originalPath: modulePath,
-        libraryName,
-        outputPath,
-        skipped: true,
-      };
-    }
-  }
 
   await fs.promises.rm(outputPath, { recursive: true, force: true });
   await fs.promises.cp(modulePath, outputPath, { recursive: true });

--- a/packages/host/src/node/cli/apple.ts
+++ b/packages/host/src/node/cli/apple.ts
@@ -421,15 +421,17 @@ export async function createAppleLinker(): Promise<ModuleLinker> {
 
   const expectedSlice = determineFrameworkSlice();
 
+  assert(
+    signingRequired !== "YES" || signingAllowed !== "NO",
+    "Expected either CODE_SIGNING_REQUIRED not be YES or CODE_SIGNING_ALLOWED not be NO",
+  );
+
   return (options: LinkModuleOptions) => {
     return linkXcframework({
       ...options,
       outputPath,
       expectedSlice,
-      signingIdentity:
-        signingRequired !== "NO" && signingAllowed !== "NO"
-          ? signingIdentity
-          : undefined,
+      signingIdentity: signingAllowed !== "NO" ? signingIdentity : undefined,
     });
   };
 }
@@ -443,6 +445,10 @@ export async function linkXcframework({
 }: LinkModuleOptions & {
   outputPath: string;
   expectedSlice: ExpectedFrameworkSlice;
+  /**
+   * If not provided, the framework will not be signed.
+   * If provided, the framework will be signed with the given identity.
+   */
   signingIdentity?: string;
 }): Promise<LinkModuleResult> {
   // Copy the xcframework to the output directory and rename the framework and binary

--- a/packages/host/src/node/cli/apple.ts
+++ b/packages/host/src/node/cli/apple.ts
@@ -482,7 +482,6 @@ export function determineFrameworkSlice(): {
 }
 
 export async function linkXcframework({
-  platform,
   modulePath,
   naming,
   outputPath: outputParentPath,
@@ -502,12 +501,7 @@ export async function linkXcframework({
 
   const info = await readXcframeworkInfo(path.join(modulePath, "Info.plist"));
 
-  // TODO: Assert the existence of environment variables injected by Xcodebuild
-  // TODO: Pick and assert the existence of the right framework slice based on the environment variables
-  // TODO: Link the framework into the output path
-
   const expectedSlice = determineFrameworkSlice();
-
   const framework = info.AvailableLibraries.find((framework) => {
     return (
       expectedSlice.platform === framework.SupportedPlatform &&

--- a/packages/host/src/node/cli/apple.ts
+++ b/packages/host/src/node/cli/apple.ts
@@ -7,16 +7,15 @@ import * as xcode from "@bacons/xcode";
 import * as xcodeJson from "@bacons/xcode/json";
 import * as zod from "zod";
 
-import { assertFixable, chalk, spawn } from "@react-native-node-api/cli-utils";
+import { chalk, spawn } from "@react-native-node-api/cli-utils";
 
-import { getLatestMtime, getLibraryName } from "../path-utils.js";
+import { getLibraryName } from "../path-utils.js";
 import {
-  getLinkedModuleOutputPath,
   LinkModuleOptions,
   LinkModuleResult,
   ModuleLinker,
 } from "./link-modules.js";
-import { findXcodeProject, getBuildDirPath } from "./xcode-helpers.js";
+import { findXcodeProject } from "./xcode-helpers.js";
 
 const PACKAGE_ROOT = path.resolve(__dirname, "..", "..", "..");
 const CLI_PATH = path.resolve(PACKAGE_ROOT, "bin", "react-native-node-api.mjs");
@@ -461,7 +460,6 @@ export function determineFrameworkSlice(): {
 export async function linkXcframework({
   platform,
   modulePath,
-  incremental,
   naming,
   outputPath: outputParentPath,
   signingIdentity,
@@ -469,13 +467,6 @@ export async function linkXcframework({
   outputPath: string;
   signingIdentity?: string;
 }): Promise<LinkModuleResult> {
-  assertFixable(
-    !incremental,
-    "Incremental linking is not supported for Apple frameworks",
-    {
-      instructions: "Run the command with the --force flag",
-    },
-  );
   // Copy the xcframework to the output directory and rename the framework and binary
   const newLibraryName = getLibraryName(modulePath, naming);
   const frameworkOutputPath = path.join(

--- a/packages/host/src/node/cli/apple.ts
+++ b/packages/host/src/node/cli/apple.ts
@@ -83,7 +83,7 @@ export async function readAndParsePlist(plistPath: string): Promise<unknown> {
         "Updating Info.plist files are not supported on this platform",
       );
       await spawn("plutil", ["-convert", "xml1", plistPath], {
-        outputMode: "inherit",
+        outputMode: "buffered",
       });
     } catch (cause) {
       throw new Error(`Failed to convert plist to XML: ${plistPath}`, {
@@ -323,6 +323,7 @@ export async function linkVersionedFramework({
     "Info.plist",
   );
   const frameworkInfo = await readFrameworkInfo(frameworkInfoPath);
+
   // Update install name
   await spawn(
     "install_name_tool",

--- a/packages/host/src/node/cli/bin.test.ts
+++ b/packages/host/src/node/cli/bin.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import cp from "node:child_process";
 import path from "node:path";
+import { setupTempDirectory } from "../test-utils";
 
 const PACKAGE_ROOT = path.join(__dirname, "../../..");
 const BIN_PATH = path.join(PACKAGE_ROOT, "bin/react-native-node-api.mjs");
@@ -32,13 +33,28 @@ describe("bin", () => {
   });
 
   describe("link command", () => {
-    it("should succeed with a mention of Node-API modules", () => {
+    it("should succeed with a mention of Node-API modules", (context) => {
+      const targetBuildDir = setupTempDirectory(context, {});
+
       const { status, stdout, stderr } = cp.spawnSync(
         process.execPath,
-        [BIN_PATH, "link", "--android", "--apple"],
+        [
+          BIN_PATH,
+          "link",
+          "--android",
+          // Linking for Apple fails on non-Apple platforms
+          ...(process.platform === "darwin" ? ["--apple"] : []),
+        ],
         {
           cwd: PACKAGE_ROOT,
           encoding: "utf8",
+          env: {
+            ...process.env,
+            TARGET_BUILD_DIR: targetBuildDir,
+            FRAMEWORKS_FOLDER_PATH: "Frameworks",
+            PLATFORM_NAME: "iphonesimulator",
+            ARCHS: "arm64",
+          },
         },
       );
 

--- a/packages/host/src/node/cli/link-modules.ts
+++ b/packages/host/src/node/cli/link-modules.ts
@@ -30,7 +30,7 @@ export type LinkModulesOptions = {
 
 export type LinkModuleOptions = Omit<
   LinkModulesOptions,
-  "fromPath" | "linker"
+  "fromPath" | "linker" | "platform"
 > & {
   modulePath: string;
 };
@@ -95,7 +95,6 @@ export async function linkModules({
         return await linker({
           modulePath: originalPath,
           naming,
-          platform,
         });
       } catch (error) {
         if (error instanceof SpawnFailure) {

--- a/packages/host/src/node/cli/link-modules.ts
+++ b/packages/host/src/node/cli/link-modules.ts
@@ -44,11 +44,13 @@ export type ModuleDetails = {
 
 export type LinkModuleResult = ModuleDetails & {
   skipped: boolean;
+  signed?: boolean;
 };
 
 export type ModuleOutputBase = {
   originalPath: string;
   skipped: boolean;
+  signed?: boolean;
 };
 
 type ModuleOutput = ModuleOutputBase &

--- a/packages/host/src/node/cli/link-modules.ts
+++ b/packages/host/src/node/cli/link-modules.ts
@@ -23,7 +23,6 @@ export type ModuleLinker = (
 
 export type LinkModulesOptions = {
   platform: PlatformName;
-  incremental: boolean;
   naming: NamingStrategy;
   fromPath: string;
   linker: ModuleLinker;
@@ -61,7 +60,6 @@ type ModuleOutput = ModuleOutputBase &
 
 export async function linkModules({
   fromPath,
-  incremental,
   naming,
   platform,
   linker,
@@ -96,7 +94,6 @@ export async function linkModules({
       try {
         return await linker({
           modulePath: originalPath,
-          incremental,
           naming,
           platform,
         });

--- a/packages/host/src/node/cli/program.ts
+++ b/packages/host/src/node/cli/program.ts
@@ -63,11 +63,6 @@ program
   .command("link")
   .argument("[path]", "Some path inside the app package", process.cwd())
   .option(
-    "--force",
-    "Don't check timestamps of input files to skip unnecessary rebuilds",
-    false,
-  )
-  .option(
     "--prune",
     "Delete vendored modules that are no longer auto-linked",
     true,
@@ -78,10 +73,7 @@ program
   .addOption(pathSuffixOption)
   .action(
     wrapAction(
-      async (
-        pathArg,
-        { force, prune, pathSuffix, android, apple, packageName },
-      ) => {
+      async (pathArg, { prune, pathSuffix, android, apple, packageName }) => {
         console.log("Auto-linking Node-API modules from", chalk.dim(pathArg));
         const platforms: PlatformName[] = [];
         if (android) {
@@ -107,7 +99,6 @@ program
               await linkModules({
                 platform,
                 fromPath: path.resolve(pathArg),
-                incremental: !force,
                 naming: { packageName, pathSuffix },
                 linker: await createLinker(platform, path.resolve(pathArg)),
               }),

--- a/packages/host/src/node/cli/program.ts
+++ b/packages/host/src/node/cli/program.ts
@@ -14,7 +14,6 @@ import {
 import {
   determineModuleContext,
   findNodeApiModulePathsByDependency,
-  getAutolinkPath,
   getLibraryName,
   visualizeLibraryMap,
   normalizeModulePath,
@@ -36,10 +35,7 @@ export const program = new Command("react-native-node-api").addCommand(
   vendorHermes,
 );
 
-async function createLinker(
-  platform: PlatformName,
-  fromPath: string,
-): Promise<ModuleLinker> {
+async function createLinker(platform: PlatformName): Promise<ModuleLinker> {
   if (platform === "android") {
     return linkAndroidDir;
   } else if (platform === "apple") {
@@ -100,7 +96,7 @@ program
                 platform,
                 fromPath: path.resolve(pathArg),
                 naming: { packageName, pathSuffix },
-                linker: await createLinker(platform, path.resolve(pathArg)),
+                linker: await createLinker(platform),
               }),
             {
               text: `Linking ${platformDisplayName} Node-API modules`,

--- a/packages/host/src/node/cli/xcode-helpers.ts
+++ b/packages/host/src/node/cli/xcode-helpers.ts
@@ -45,7 +45,7 @@ export async function readXcodeWorkspace(workspacePath: string) {
 
 export async function findXcodeWorkspace(fromPath: string) {
   // Check if the directory contains a Xcode workspace
-  const xcodeWorkspace = await fs.promises.glob(path.join("*.xcworkspace"), {
+  const xcodeWorkspace = fs.promises.glob(path.join("*.xcworkspace"), {
     cwd: fromPath,
   });
 

--- a/packages/host/src/node/cli/xcode-helpers.ts
+++ b/packages/host/src/node/cli/xcode-helpers.ts
@@ -1,0 +1,138 @@
+import assert from "node:assert";
+import path from "node:path";
+import fs from "node:fs";
+import cp from "node:child_process";
+
+// Using xmldom here because this is what @expo/plist uses internally and we might as well re-use it here.
+// Types come from packages/host/types/xmldom.d.ts (path mapping in tsconfig.node.json) to avoid pulling in lib "dom".
+import { DOMParser } from "@xmldom/xmldom";
+import xcode from "@bacons/xcode";
+import * as zod from "zod";
+
+export type XcodeWorkspace = {
+  version: string;
+  fileRefs: {
+    location: string;
+  }[];
+};
+
+export async function readXcodeWorkspace(workspacePath: string) {
+  const dataFilePath = path.join(workspacePath, "contents.xcworkspacedata");
+  assert(
+    fs.existsSync(dataFilePath),
+    `Expected a contents.xcworkspacedata file at '${dataFilePath}'`,
+  );
+  const xml = await fs.promises.readFile(dataFilePath, "utf-8");
+  const dom = new DOMParser().parseFromString(xml, "application/xml");
+  const version = dom.documentElement.getAttribute("version") ?? "1.0";
+  assert.equal(version, "1.0", "Unexpected workspace version");
+
+  const result: XcodeWorkspace = {
+    version,
+    fileRefs: [],
+  };
+  const fileRefs = dom.documentElement.getElementsByTagName("FileRef");
+  for (let i = 0; i < fileRefs.length; i++) {
+    const fileRef = fileRefs.item(i);
+    if (fileRef) {
+      const location = fileRef.getAttribute("location");
+      if (location) {
+        result.fileRefs.push({
+          location,
+        });
+      }
+    }
+  }
+  return result;
+}
+
+export async function findXcodeWorkspace(fromPath: string) {
+  // Check if the directory contains a Xcode workspace
+  const xcodeWorkspace = await fs.promises.glob(path.join("*.xcworkspace"), {
+    cwd: fromPath,
+  });
+
+  for await (const workspace of xcodeWorkspace) {
+    return path.join(fromPath, workspace);
+  }
+
+  // Check if the directory contain an ios directory and call recursively from that
+  const iosDirectory = path.join(fromPath, "ios");
+  if (fs.existsSync(iosDirectory)) {
+    return findXcodeWorkspace(iosDirectory);
+  }
+
+  // TODO: Consider continuing searching in parent directories
+  throw new Error(`No Xcode workspace found in '${fromPath}'`);
+}
+
+export async function findXcodeProject(fromPath: string) {
+  // Read the workspace contents to find the first project
+  const workspacePath = await findXcodeWorkspace(fromPath);
+  const workspace = await readXcodeWorkspace(workspacePath);
+  // Resolve the first project location to an absolute path
+  assert(
+    workspace.fileRefs.length > 0,
+    "Expected at least one project in the workspace",
+  );
+  const [firstProject] = workspace.fileRefs;
+  // Extract the path from the scheme (using a regex)
+  const match = firstProject.location.match(/^([^:]*):(.*)$/);
+  assert(match, "Expected a project path in the workspace");
+  const [, scheme, projectPath] = match;
+  assert(scheme, "Expected a scheme in the fileRef location");
+  assert(projectPath, "Expected a path in the fileRef location");
+  if (scheme === "absolute") {
+    return projectPath;
+  } else if (scheme === "group") {
+    return path.resolve(path.dirname(workspacePath), projectPath);
+  } else {
+    throw new Error(`Unexpected scheme: ${scheme}`);
+  }
+}
+
+const BuildSettingsSchema = zod.array(
+  zod.object({
+    target: zod.string(),
+    buildSettings: zod.partialRecord(zod.string(), zod.string()),
+  }),
+);
+
+export function getBuildSettings(
+  xcodeProjectPath: string,
+  mainTarget: xcode.PBXNativeTarget,
+) {
+  const result = cp.spawnSync(
+    "xcodebuild",
+    [
+      "-showBuildSettings",
+      "-project",
+      xcodeProjectPath,
+      "-target",
+      mainTarget.getDisplayName(),
+      "-json",
+    ],
+    {
+      cwd: xcodeProjectPath,
+      encoding: "utf-8",
+    },
+  );
+  assert.equal(
+    result.status,
+    0,
+    `Failed to run xcodebuild -showBuildSettings: ${result.stderr}`,
+  );
+  return BuildSettingsSchema.parse(JSON.parse(result.stdout));
+}
+
+export function getBuildDirPath(
+  xcodeProjectPath: string,
+  mainTarget: xcode.PBXNativeTarget,
+) {
+  const buildSettings = getBuildSettings(xcodeProjectPath, mainTarget);
+  assert(buildSettings.length === 1, "Expected exactly one build setting");
+  const [targetBuildSettings] = buildSettings;
+  const { BUILD_DIR: buildDirPath } = targetBuildSettings.buildSettings;
+  assert(buildDirPath, "Expected a build directory");
+  return buildDirPath;
+}

--- a/packages/host/src/node/cli/xcode-helpers.ts
+++ b/packages/host/src/node/cli/xcode-helpers.ts
@@ -1,7 +1,6 @@
 import assert from "node:assert";
 import path from "node:path";
 import fs from "node:fs";
-import cp from "node:child_process";
 
 // Using xmldom here because this is what @expo/plist uses internally and we might as well re-use it here.
 // Types come from packages/host/types/xmldom.d.ts (path mapping in tsconfig.node.json) to avoid pulling in lib "dom".

--- a/packages/host/src/node/cli/xcode-helpers.ts
+++ b/packages/host/src/node/cli/xcode-helpers.ts
@@ -53,10 +53,15 @@ export async function findXcodeWorkspace(fromPath: string) {
     return path.join(fromPath, workspace);
   }
 
-  // Check if the directory contain an ios directory and call recursively from that
+  // Check if the directory contains an "ios" or a "macos" directory and call recursively from that
   const iosDirectory = path.join(fromPath, "ios");
   if (fs.existsSync(iosDirectory)) {
     return findXcodeWorkspace(iosDirectory);
+  }
+
+  const macosDirectory = path.join(fromPath, "macos");
+  if (fs.existsSync(macosDirectory)) {
+    return findXcodeWorkspace(macosDirectory);
   }
 
   // TODO: Consider continuing searching in parent directories

--- a/packages/host/tsconfig.node.json
+++ b/packages/host/tsconfig.node.json
@@ -5,7 +5,11 @@
     "declarationMap": true,
     "outDir": "dist",
     "rootDir": "src",
-    "types": ["node"]
+    "types": ["node"],
+    "baseUrl": ".",
+    "paths": {
+      "@xmldom/xmldom": ["./types/xmldom.d.ts"]
+    }
   },
   "include": ["src/node/**/*.ts", "types/**/*.d.ts"],
   "exclude": ["**/*.test.ts"],

--- a/packages/host/types/xmldom.d.ts
+++ b/packages/host/types/xmldom.d.ts
@@ -1,0 +1,43 @@
+/**
+ * Local type declaration for @xmldom/xmldom that does not pull in lib "dom".
+ * Used via path mapping in tsconfig.node.json so we get correct xmldom types
+ * without bleeding global DOM types (Document, Node, Element, etc.) into the project.
+ */
+declare module "@xmldom/xmldom" {
+  interface XmldomDocument {
+    readonly documentElement: XmldomElement;
+  }
+
+  interface XmldomElement {
+    getAttribute(name: string): string | null;
+    getElementsByTagName(name: string): XmldomNodeList<XmldomElement>;
+  }
+
+  interface XmldomNodeList<T = XmldomElement> {
+    readonly length: number;
+    item(index: number): T | null;
+  }
+
+  interface XmldomDOMParserOptions {
+    locator?: unknown;
+    errorHandler?:
+      | ((level: string, msg: unknown) => unknown)
+      | {
+          warning?: (msg: unknown) => unknown;
+          error?: (msg: unknown) => unknown;
+          fatalError?: (msg: unknown) => unknown;
+        };
+  }
+
+  interface XmldomDOMParserInstance {
+    parseFromString(xmlsource: string, mimeType?: string): XmldomDocument;
+  }
+
+  interface XmldomDOMParserStatic {
+    new (options?: XmldomDOMParserOptions): XmldomDOMParserInstance;
+  }
+
+  export const DOMParser: XmldomDOMParserStatic;
+  export const XMLSerializer: unknown;
+  export const DOMImplementation: unknown;
+}


### PR DESCRIPTION
Fixes #23, #213 and #262 by modifying the Xcode project after it has been generated by CocoaPods.

Merging this PR will:
- Add a `patch-xcode-project` command to the host CLI: When called, it will modify the main Xcode app target[^1] to include a build phase which calls into the CLI with `link --apple` args.
- Add an exit hook to the host package's podspec to conveniently run the `patch-xcode-project` command. Since users can run this commend themselves or we could drive it from a SPM project, I don't consider this a dependency on CocoaPods as such.
- Modify the Apple link command to expect invocation from inside a build phase, to copy, renaming and signing frameworks (not xcframeworks) to their final destination in the app 
bundle, based on environment variables provided by Xcode.

Because the frameworks are no longer explicitly referenced by targets we also don't have the (currently untracked) issue of the dynamic libraries being loaded at startup time. Which means faster boot times and less concern about the order of operations as they'll be loaded when required by the app.

[^1]: We could have added it as a build phase to our own host package's pod target, but then we'd need an additional phase to move the frameworks slices from the pod target into the app bundle - which seems wasteful. Instead I suggest just driving the discovery and embedding of addon frameworks directly from a build phase on the app target.
