### PR TITLE
Enable source maps across CLIs

### DIFF
--- a/.changeset/nice-crews-wonder.md
+++ b/.changeset/nice-crews-wonder.md
@@ -1,0 +1,8 @@
+---
+"gyp-to-cmake": patch
+"cmake-rn": patch
+"ferric-cli": patch
+"react-native-node-api": patch
+---
+
+Add support for source maps across CLI bins

--- a/packages/cmake-rn/bin/cmake-rn.js
+++ b/packages/cmake-rn/bin/cmake-rn.js
@@ -1,2 +1,2 @@
-#!/usr/bin/env node
+#!/usr/bin/env -S node --enable-source-maps
 import "../dist/run.js";

--- a/packages/ferric/bin/ferric.js
+++ b/packages/ferric/bin/ferric.js
@@ -1,2 +1,2 @@
-#!/usr/bin/env node
+#!/usr/bin/env -S node --enable-source-maps
 import "../dist/run.js";

--- a/packages/gyp-to-cmake/bin/gyp-to-cmake.js
+++ b/packages/gyp-to-cmake/bin/gyp-to-cmake.js
@@ -1,2 +1,2 @@
-#!/usr/bin/env node
+#!/usr/bin/env -S node --enable-source-maps
 import "../dist/run.js";

--- a/packages/host/bin/react-native-node-api.mjs
+++ b/packages/host/bin/react-native-node-api.mjs
@@ -1,2 +1,2 @@
-#!/usr/bin/env node
+#!/usr/bin/env -S node --enable-source-maps
 import "../dist/node/cli/run.js";


### PR DESCRIPTION
Merging this PR will:
- Ensure all CLIs are started with source maps enabled, for better error reporting on catastrophic failures.