### PR TITLE
Add `reactNativeNodeApi ` field support for `package.json`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -137,7 +137,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.4.tgz",
       "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
@@ -2331,6 +2330,16 @@
       "optional": true,
       "dependencies": {
         "@emnapi/wasi-threads": "1.1.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.8.1.tgz",
+      "integrity": "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
         "tslib": "^2.4.0"
       }
     },
@@ -4832,7 +4841,6 @@
       "resolved": "https://registry.npmjs.org/@octokit/core/-/core-7.0.4.tgz",
       "integrity": "sha512-jOT8V1Ba5BdC79sKrRWDdMT5l1R+XNHTPR6CPWzUP2EcfAcvIHZWF0eAbmRcpOOP5gVIwnqNg0C4nvh6Abc3OA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.1",
@@ -6017,7 +6025,6 @@
       "resolved": "https://registry.npmjs.org/@react-native/metro-config/-/metro-config-0.81.4.tgz",
       "integrity": "sha512-aEXhRMsz6yN5X63Zk+cdKByQ0j3dsKv+ETRP9lLARdZ82fBOCMuK6IfmZMwK3A/3bI7gSvt2MFPn3QHy3WnByw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@react-native/js-polyfills": "0.81.4",
         "@react-native/metro-babel-transformer": "0.81.4",
@@ -6641,7 +6648,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.18.6.tgz",
       "integrity": "sha512-r8uszLPpeIWbNKtvWRt/DbVi5zbqZyj1PTmhRMqBMvDnaz1QpmSKujUtJLrqGZeoM8v72MfYggDceY4K1itzWQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -6735,7 +6741,6 @@
       "integrity": "sha512-VGMpFQGUQWYT9LfnPcX8ouFojyrZ/2w3K5BucvxL/spdNehccKhB4jUyB1yBCXpr2XFm0jkECxgrpXBW2ipoAw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.44.0",
         "@typescript-eslint/types": "8.44.0",
@@ -7076,7 +7081,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -7670,7 +7674,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.3",
         "caniuse-lite": "^1.0.30001741",
@@ -9071,7 +9074,6 @@
       "integrity": "sha512-QePbBFMJFjgmlE+cXAlbHZbHpdFVS2E/6vzCy7aKlebddvl1vadiC4JFV5u/wqTkNUwEV8WrQi257jf5f06hrg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -12264,8 +12266,7 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/node-api-headers/-/node-api-headers-1.5.0.tgz",
       "integrity": "sha512-Yi/FgnN8IU/Cd6KeLxyHkylBUvDTsSScT0Tna2zTrz8klmc8qF2ppj6Q1LHsmOueJWhigQwR4cO2p0XBGW5IaQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/node-int64": {
       "version": "0.4.0",
@@ -13115,7 +13116,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
       "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -13162,7 +13162,6 @@
       "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.81.4.tgz",
       "integrity": "sha512-bt5bz3A/+Cv46KcjV0VQa+fo7MKxs17RCcpzjftINlen4ZDUl0I6Ut+brQ2FToa5oD0IB0xvQHfmsg2EDqsZdQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/create-cache-key-function": "^29.7.0",
         "@react-native/assets-registry": "0.81.4",
@@ -14600,7 +14599,6 @@
       "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -15179,7 +15177,6 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.1.tgz",
       "integrity": "sha512-2JkV3gUZUVrbNA+1sjBOYLsMZ5cEEl8GTFP2a4AVz5hvasAMCQ1D2l2le/cX+pV4N6ZU17zjUahLpIXRrnWL8A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20"
       }

--- a/packages/host/src/node/path-utils.test.ts
+++ b/packages/host/src/node/path-utils.test.ts
@@ -541,6 +541,50 @@ describe("findNodeApiModulePathsByDependency", () => {
     });
   });
 
+  it("should find Node-API paths by dependency in root package.json with bad configuration (excluding certain packages)", async (context) => {
+    const packagesNames = ["lib-a", "lib-b", "lib-c", "lib-d", "lib-e"];
+    const tempDir = setupTempDirectory(context, {
+      "app/package.json": JSON.stringify({
+        name: "app",
+        dependencies: Object.fromEntries(
+          packagesNames
+            .slice(0, 2)
+            .map((packageName) => [packageName, "^1.0.0"]),
+        ),
+        reactNativeNodeApi: {
+          scan: "lib-e",
+        },
+      }),
+      ...Object.fromEntries(
+        packagesNames.map((packageName) => [
+          `app/node_modules/${packageName}`,
+          {
+            "package.json": JSON.stringify({
+              name: packageName,
+              main: "index.js",
+            }),
+            "index.js": "",
+            "addon.apple.node/react-native-node-api-module": "",
+          },
+        ]),
+      ),
+    });
+
+    // shouldn't drop error
+    const result = await findNodeApiModulePathsByDependency({
+      fromPath: path.join(tempDir, "app"),
+      platform: "apple",
+      includeSelf: false,
+      excludePackages: ["lib-a"],
+    });
+    assert.deepEqual(result, {
+      "lib-b": {
+        path: path.join(tempDir, "app/node_modules/lib-b"),
+        modulePaths: ["addon.apple.node"],
+      },
+    });
+  });
+
   it("should find Node-API paths by dependency in root package.json configuration with incorrect dependency configuration (excluding certain packages)", async (context) => {
     const packagesNames = ["lib-a", "lib-b", "lib-c", "lib-d"];
     const tempDir = setupTempDirectory(context, {
@@ -706,7 +750,7 @@ describe("findNodeApiModulePathsByDependency", () => {
         packagesNames.slice(1).map((packageName, i) => {
           // if even then i-1
           // if not even then i+1
-          const dependencyIndex = i + ((i % 2) * 2 - 1)
+          const dependencyIndex = i + ((i % 2) * 2 - 1);
 
           return [
             `app/node_modules/${packageName}`,

--- a/packages/host/src/node/path-utils.test.ts
+++ b/packages/host/src/node/path-utils.test.ts
@@ -657,25 +657,31 @@ describe("findNodeApiModulePathsByDependency", () => {
         ),
       }),
       ...Object.fromEntries(
-        packagesNames.slice(1).map((packageName, i) => [
-          `app/node_modules/${packageName}`,
-          {
-            "package.json": JSON.stringify({
-              name: packageName,
-              main: "index.js",
-              reactNativeNodeApi: {
-                scan: {
-                  dependencies:
-                    packagesNames[i + ((i % 2) * 2 - 1)] != null
-                      ? [packagesNames[i + ((i % 2) * 2 - 1)]]
-                      : [],
+        packagesNames.slice(1).map((packageName, i) => {
+          // if even then i-1
+          // if not even then i+1
+          const dependencyIndex = i + ((i % 2) * 2 - 1)
+
+          return [
+            `app/node_modules/${packageName}`,
+            {
+              "package.json": JSON.stringify({
+                name: packageName,
+                main: "index.js",
+                reactNativeNodeApi: {
+                  scan: {
+                    dependencies:
+                      packagesNames[dependencyIndex] != null
+                        ? [packagesNames[dependencyIndex]]
+                        : [],
+                  },
                 },
-              },
-            }),
-            "index.js": "",
-            "addon.apple.node/react-native-node-api-module": "",
-          },
-        ]),
+              }),
+              "index.js": "",
+              "addon.apple.node/react-native-node-api-module": "",
+            },
+          ];
+        }),
       ),
     });
 

--- a/packages/host/src/node/path-utils.test.ts
+++ b/packages/host/src/node/path-utils.test.ts
@@ -491,7 +491,7 @@ describe("findNodeApiModulePathsByDependency", () => {
   });
 });
 
-describe("findNodeApiModulePathsByConfiguration", () => {
+describe("findNodeApiModulePathsByDependency", () => {
   it("should find Node-API paths by dependency in root package.json configuration (excluding certain packages)", async (context) => {
     const packagesNames = ["lib-a", "lib-b", "lib-c", "lib-d", "lib-e"];
     const tempDir = setupTempDirectory(context, {

--- a/packages/host/src/node/path-utils.test.ts
+++ b/packages/host/src/node/path-utils.test.ts
@@ -541,6 +541,52 @@ describe("findNodeApiModulePathsByDependency", () => {
     });
   });
 
+  it("should find Node-API paths by dependency in root package.json configuration with incorrect dependency configuration (excluding certain packages)", async (context) => {
+    const packagesNames = ["lib-a", "lib-b", "lib-c", "lib-d"];
+    const tempDir = setupTempDirectory(context, {
+      "app/package.json": JSON.stringify({
+        name: "app",
+        dependencies: Object.fromEntries(
+          packagesNames
+            .slice(0, 2)
+            .map((packageName) => [packageName, "^1.0.0"]),
+        ),
+        reactNativeNodeApi: {
+          scan: {
+            dependencies: ["lib-e"],
+          },
+        },
+      }),
+      ...Object.fromEntries(
+        packagesNames.map((packageName) => [
+          `app/node_modules/${packageName}`,
+          {
+            "package.json": JSON.stringify({
+              name: packageName,
+              main: "index.js",
+            }),
+            "index.js": "",
+            "addon.apple.node/react-native-node-api-module": "",
+          },
+        ]),
+      ),
+    });
+
+    // shouldn't find lib-e
+    const result = await findNodeApiModulePathsByDependency({
+      fromPath: path.join(tempDir, "app"),
+      platform: "apple",
+      includeSelf: false,
+      excludePackages: ["lib-a"],
+    });
+    assert.deepEqual(result, {
+      "lib-b": {
+        path: path.join(tempDir, "app/node_modules/lib-b"),
+        modulePaths: ["addon.apple.node"],
+      },
+    });
+  });
+
   it("should find Node-API paths by dependency in child modules configuration (excluding certain packages)", async (context) => {
     const packagesNames = ["lib-a", "lib-b", "lib-c", "lib-d", "lib-e"];
     const tempDir = setupTempDirectory(context, {

--- a/packages/host/src/node/path-utils.test.ts
+++ b/packages/host/src/node/path-utils.test.ts
@@ -491,6 +491,318 @@ describe("findNodeApiModulePathsByDependency", () => {
   });
 });
 
+describe("findNodeApiModulePathsByConfiguration", () => {
+  it("should find Node-API paths by dependency in root package.json configuration (excluding certain packages)", async (context) => {
+    const packagesNames = ["lib-a", "lib-b", "lib-c", "lib-d", "lib-e"];
+    const tempDir = setupTempDirectory(context, {
+      "app/package.json": JSON.stringify({
+        name: "app",
+        dependencies: Object.fromEntries(
+          packagesNames
+            .slice(0, 2)
+            .map((packageName) => [packageName, "^1.0.0"]),
+        ),
+        reactNativeNodeApi: {
+          scan: {
+            dependencies: ["lib-e"],
+          },
+        },
+      }),
+      ...Object.fromEntries(
+        packagesNames.map((packageName) => [
+          `app/node_modules/${packageName}`,
+          {
+            "package.json": JSON.stringify({
+              name: packageName,
+              main: "index.js",
+            }),
+            "index.js": "",
+            "addon.apple.node/react-native-node-api-module": "",
+          },
+        ]),
+      ),
+    });
+
+    const result = await findNodeApiModulePathsByDependency({
+      fromPath: path.join(tempDir, "app"),
+      platform: "apple",
+      includeSelf: false,
+      excludePackages: ["lib-a"],
+    });
+    assert.deepEqual(result, {
+      "lib-b": {
+        path: path.join(tempDir, "app/node_modules/lib-b"),
+        modulePaths: ["addon.apple.node"],
+      },
+      "lib-e": {
+        path: path.join(tempDir, "app/node_modules/lib-e"),
+        modulePaths: ["addon.apple.node"],
+      },
+    });
+  });
+
+  it("should find Node-API paths by dependency in child modules configuration (excluding certain packages)", async (context) => {
+    const packagesNames = ["lib-a", "lib-b", "lib-c", "lib-d", "lib-e"];
+    const tempDir = setupTempDirectory(context, {
+      "app/package.json": JSON.stringify({
+        name: "app",
+        dependencies: Object.fromEntries(
+          packagesNames
+            .slice(0, 3)
+            .map((packageName) => [packageName, "^1.0.0"]),
+        ),
+      }),
+      ...Object.fromEntries(
+        packagesNames.slice(1).map((packageName, i) => [
+          `app/node_modules/${packageName}`,
+          {
+            "package.json": JSON.stringify({
+              name: packageName,
+              main: "index.js",
+              reactNativeNodeApi: {
+                scan: {
+                  dependencies:
+                    packagesNames[i + 2] != null ? [packagesNames[i + 2]] : [],
+                },
+              },
+            }),
+            "index.js": "",
+            "addon.apple.node/react-native-node-api-module": "",
+          },
+        ]),
+      ),
+    });
+
+    const result = await findNodeApiModulePathsByDependency({
+      fromPath: path.join(tempDir, "app"),
+      platform: "apple",
+      includeSelf: false,
+      excludePackages: ["lib-a"],
+    });
+    assert.deepEqual(result, {
+      "lib-b": {
+        path: path.join(tempDir, "app/node_modules/lib-b"),
+        modulePaths: ["addon.apple.node"],
+      },
+      "lib-c": {
+        path: path.join(tempDir, "app/node_modules/lib-c"),
+        modulePaths: ["addon.apple.node"],
+      },
+      "lib-d": {
+        path: path.join(tempDir, "app/node_modules/lib-d"),
+        modulePaths: ["addon.apple.node"],
+      },
+      "lib-e": {
+        path: path.join(tempDir, "app/node_modules/lib-e"),
+        modulePaths: ["addon.apple.node"],
+      },
+    });
+  });
+
+  it("shouldn't find Node-API paths that not set in any place", async (context) => {
+    const packagesNames = ["lib-a", "lib-b", "lib-c", "lib-d", "lib-e"];
+    const tempDir = setupTempDirectory(context, {
+      "app/package.json": JSON.stringify({
+        name: "app",
+        dependencies: Object.fromEntries(
+          packagesNames
+            .slice(0, -1)
+            .map((packageName) => [packageName, "^1.0.0"]),
+        ),
+      }),
+      ...Object.fromEntries(
+        packagesNames.slice(1).map((packageName) => [
+          `app/node_modules/${packageName}`,
+          {
+            "package.json": JSON.stringify({
+              name: packageName,
+              main: "index.js",
+            }),
+            "index.js": "",
+            "addon.apple.node/react-native-node-api-module": "",
+          },
+        ]),
+      ),
+    });
+
+    const result = await findNodeApiModulePathsByDependency({
+      fromPath: path.join(tempDir, "app"),
+      platform: "apple",
+      includeSelf: false,
+      excludePackages: ["lib-a"],
+    });
+    assert.deepEqual(result, {
+      "lib-b": {
+        path: path.join(tempDir, "app/node_modules/lib-b"),
+        modulePaths: ["addon.apple.node"],
+      },
+      "lib-c": {
+        path: path.join(tempDir, "app/node_modules/lib-c"),
+        modulePaths: ["addon.apple.node"],
+      },
+      "lib-d": {
+        path: path.join(tempDir, "app/node_modules/lib-d"),
+        modulePaths: ["addon.apple.node"],
+      },
+    });
+  });
+
+  it("shouldn't loop when searching Node-API paths", async (context) => {
+    const packagesNames = ["lib-a", "lib-b", "lib-c", "lib-d", "lib-e"];
+    const tempDir = setupTempDirectory(context, {
+      "app/package.json": JSON.stringify({
+        name: "app",
+        dependencies: Object.fromEntries(
+          packagesNames.map((packageName) => [packageName, "^1.0.0"]),
+        ),
+      }),
+      ...Object.fromEntries(
+        packagesNames.slice(1).map((packageName, i) => [
+          `app/node_modules/${packageName}`,
+          {
+            "package.json": JSON.stringify({
+              name: packageName,
+              main: "index.js",
+              reactNativeNodeApi: {
+                scan: {
+                  dependencies:
+                    packagesNames[i + ((i % 2) * 2 - 1)] != null
+                      ? [packagesNames[i + ((i % 2) * 2 - 1)]]
+                      : [],
+                },
+              },
+            }),
+            "index.js": "",
+            "addon.apple.node/react-native-node-api-module": "",
+          },
+        ]),
+      ),
+    });
+
+    const result = await findNodeApiModulePathsByDependency({
+      fromPath: path.join(tempDir, "app"),
+      platform: "apple",
+      includeSelf: false,
+      excludePackages: ["lib-a"],
+    });
+    assert.deepEqual(result, {
+      "lib-b": {
+        path: path.join(tempDir, "app/node_modules/lib-b"),
+        modulePaths: ["addon.apple.node"],
+      },
+      "lib-c": {
+        path: path.join(tempDir, "app/node_modules/lib-c"),
+        modulePaths: ["addon.apple.node"],
+      },
+      "lib-d": {
+        path: path.join(tempDir, "app/node_modules/lib-d"),
+        modulePaths: ["addon.apple.node"],
+      },
+      "lib-e": {
+        path: path.join(tempDir, "app/node_modules/lib-e"),
+        modulePaths: ["addon.apple.node"],
+      },
+    });
+  });
+
+  it("should find Node-API paths by dependency in different layers config (excluding certain packages)", async (context) => {
+    // lib-e - default module without node-api
+    const packagesNames = [
+      "lib-a",
+      "lib-b",
+      "lib-c",
+      "lib-d",
+      "lib-e",
+      "lib-f",
+    ];
+    const tempDir = setupTempDirectory(context, {
+      "app/package.json": JSON.stringify({
+        name: "app",
+        dependencies: Object.fromEntries(
+          packagesNames
+            .slice(0, 2)
+            .map((packageName) => [packageName, "^1.0.0"]),
+        ),
+      }),
+      "app/node_modules/lib-b": {
+        "package.json": JSON.stringify({
+          name: "lib-b",
+          main: "index.js",
+          dependencies: packagesNames.slice(2, 4),
+          reactNativeNodeApi: {
+            scan: {
+              dependencies: packagesNames.slice(2, 4),
+            },
+          },
+        }),
+        "index.js": "",
+        "addon.apple.node/react-native-node-api-module": "",
+      },
+      ...Object.fromEntries(
+        packagesNames.slice(2, 4).map((packageName, i) => [
+          `app/node_modules/${packageName}`,
+          {
+            "package.json": JSON.stringify({
+              name: packageName,
+              main: "index.js",
+              dependencies: [packagesNames[i + 4]],
+              reactNativeNodeApi: {
+                scan: {
+                  dependencies: [packagesNames[i + 4]],
+                },
+              },
+            }),
+            "index.js": "",
+            "addon.apple.node/react-native-node-api-module": "",
+          },
+        ]),
+      ),
+      ...Object.fromEntries(
+        packagesNames.slice(4, 6).map((packageName) => [
+          `app/node_modules/${packageName}`,
+          {
+            "package.json": JSON.stringify({
+              name: packageName,
+              main: "index.js",
+            }),
+            "index.js": "",
+            "addon.apple.node/react-native-node-api-module": "",
+          },
+        ]),
+      ),
+    });
+
+    const result = await findNodeApiModulePathsByDependency({
+      fromPath: path.join(tempDir, "app"),
+      platform: "apple",
+      includeSelf: false,
+      excludePackages: ["lib-a"],
+    });
+    assert.deepEqual(result, {
+      "lib-b": {
+        path: path.join(tempDir, "app/node_modules/lib-b"),
+        modulePaths: ["addon.apple.node"],
+      },
+      "lib-c": {
+        path: path.join(tempDir, "app/node_modules/lib-c"),
+        modulePaths: ["addon.apple.node"],
+      },
+      "lib-d": {
+        path: path.join(tempDir, "app/node_modules/lib-d"),
+        modulePaths: ["addon.apple.node"],
+      },
+      "lib-e": {
+        path: path.join(tempDir, "app/node_modules/lib-e"),
+        modulePaths: ["addon.apple.node"],
+      },
+      "lib-f": {
+        path: path.join(tempDir, "app/node_modules/lib-f"),
+        modulePaths: ["addon.apple.node"],
+      },
+    });
+  });
+});
+
 describe("determineModuleContext", () => {
   it("should read package.json only once across multiple module paths for the same package", (context) => {
     const tempDir = setupTempDirectory(context, {

--- a/packages/host/src/node/path-utils.ts
+++ b/packages/host/src/node/path-utils.ts
@@ -308,23 +308,27 @@ export function findPackageDependencyPaths(
     path.join(packageRoot, "noop.js"),
   );
 
-  const { dependencies = {}, napiDependencies = [] } = readPackageSync({ cwd: packageRoot });
+  const { dependencies = {}, napiDependencies = [] } = readPackageSync({
+    cwd: packageRoot,
+  });
 
   const safeNApiDependencies: string[] = Array.isArray(napiDependencies)
     ? napiDependencies.map(String)
     : [];
 
   return Object.fromEntries(
-    Object.keys(dependencies).concat(safeNApiDependencies).flatMap((dependencyName) => {
-      const resolvedDependencyRoot = resolvePackageRoot(
-        requireFromPackageRoot,
-        dependencyName,
-      );
+    Object.keys(dependencies)
+      .concat(safeNApiDependencies)
+      .flatMap((dependencyName) => {
+        const resolvedDependencyRoot = resolvePackageRoot(
+          requireFromPackageRoot,
+          dependencyName,
+        );
 
-      return resolvedDependencyRoot
-        ? [[dependencyName, resolvedDependencyRoot]]
-        : [];
-    }),
+        return resolvedDependencyRoot
+          ? [[dependencyName, resolvedDependencyRoot]]
+          : [];
+      }),
   );
 }
 

--- a/packages/host/src/node/path-utils.ts
+++ b/packages/host/src/node/path-utils.ts
@@ -308,14 +308,19 @@ export function findPackageDependencyPaths(
     path.join(packageRoot, "noop.js"),
   );
 
-  const { dependencies = {} } = readPackageSync({ cwd: packageRoot });
+  const { dependencies = {}, napiDependencies = [] } = readPackageSync({ cwd: packageRoot });
+
+  const safeNApiDependencies: string[] = Array.isArray(napiDependencies)
+    ? napiDependencies.map(String)
+    : [];
 
   return Object.fromEntries(
-    Object.keys(dependencies).flatMap((dependencyName) => {
+    Object.keys(dependencies).concat(safeNApiDependencies).flatMap((dependencyName) => {
       const resolvedDependencyRoot = resolvePackageRoot(
         requireFromPackageRoot,
         dependencyName,
       );
+
       return resolvedDependencyRoot
         ? [[dependencyName, resolvedDependencyRoot]]
         : [];

--- a/packages/host/src/node/path-utils.ts
+++ b/packages/host/src/node/path-utils.ts
@@ -345,7 +345,9 @@ export function findPackageDependencyPaths(
   const packageRoot = packageDirectorySync({ cwd: fromPath });
   assert(packageRoot, `Could not find package root from ${fromPath}`);
 
-  const requireFromRoot = createRequire(path.join(packageRoot, "noop.js"));
+  const requireFromRoot: NodeRequire = createRequire(
+    path.join(packageRoot, "noop.js"),
+  );
 
   const packageJson = readPackageSync({
     cwd: packageRoot,
@@ -360,27 +362,37 @@ export function findPackageDependencyPaths(
     reactNativeNodeApi?.scan?.dependencies ?? [],
   );
 
-  return Object.fromEntries(
-    initialDeps.flatMap((name) => {
-      const root = resolvePackageRoot(requireFromRoot, name);
-      if (!root) return [];
+  const result: Record<string, string> = {};
+  const visited = new Set<string>();
+  const queue: Array<string> = [...initialDeps];
 
-      const nested =
-        findPackageConfigurationByPath(root)?.reactNativeNodeApi?.scan
-          ?.dependencies ?? [];
+  while (queue.length > 0) {
+    const name = queue.shift()!;
 
-      const nestedEntries = nested
-        .map((nestedName) => {
-          const nestedRoot = resolvePackageRoot(requireFromRoot, nestedName);
-          return nestedRoot
-            ? ([nestedName, nestedRoot] as [string, string])
-            : null;
-        })
-        .filter((entry): entry is [string, string] => entry !== null);
+    if (visited.has(name)) {
+      continue;
+    }
+    visited.add(name);
 
-      return [[name, root] as [string, string], ...nestedEntries];
-    }),
-  );
+    const root = resolvePackageRoot(requireFromRoot, name);
+    if (!root) {
+      continue;
+    }
+
+    result[name] = root;
+
+    const config = findPackageConfigurationByPath(root);
+    const nestedDependencies =
+      config?.reactNativeNodeApi?.scan?.dependencies ?? [];
+
+    for (const nestedName of nestedDependencies) {
+      if (!visited.has(nestedName)) {
+        queue.push(nestedName);
+      }
+    }
+  }
+
+  return result;
 }
 
 export const MAGIC_FILENAME = "react-native-node-api-module";

--- a/packages/host/src/node/path-utils.ts
+++ b/packages/host/src/node/path-utils.ts
@@ -2,8 +2,9 @@ import assert from "node:assert/strict";
 import path from "node:path";
 import fs from "node:fs";
 import { packageDirectorySync } from "pkg-dir";
-import { NormalizedPackageJson, readPackageSync } from "read-pkg";
+import { readPackageSync } from "read-pkg";
 import { createRequire } from "node:module";
+import * as zod from "zod";
 
 import { chalk, prettyPath } from "@react-native-node-api/cli-utils";
 
@@ -294,31 +295,44 @@ export function visualizeLibraryMap(libraryMap: LibraryMap) {
   return result.join("\n");
 }
 
+export const ReactNativeNodeAPIConfigurationSchema = zod.object({
+  reactNativeNodeApi: zod
+    .object({
+      scan: zod
+        .object({
+          dependencies: zod.array(zod.string()).optional(),
+        })
+        .optional(),
+    })
+    .optional(),
+});
+
+export const PackageJsonDependenciesSchema = zod.object({
+  dependencies: zod.record(zod.string(), zod.string()).optional(),
+});
+
+export type ReactNativeNodeAPIConfiguration = zod.infer<
+  typeof ReactNativeNodeAPIConfigurationSchema
+>;
+export type PackageJsonDependencies = zod.infer<
+  typeof PackageJsonDependenciesSchema
+>;
+
+type PackageJsonWithNodeApi = PackageJsonDependencies &
+  ReactNativeNodeAPIConfiguration;
+
 export function findPackageConfigurationByPath(
   fromPath: string,
 ): ReactNativeNodeAPIConfiguration {
   const packageRoot = packageDirectorySync({ cwd: fromPath });
   assert(packageRoot, `Could not find package root from ${fromPath}`);
 
-  const {
-    reactNativeNodeApi,
-  }: NormalizedPackageJson & ReactNativeNodeAPIConfiguration = readPackageSync({
+  const packageJson = readPackageSync({
     cwd: packageRoot,
   });
 
-  return { reactNativeNodeApi };
+  return ReactNativeNodeAPIConfigurationSchema.parse(packageJson);
 }
-
-export interface ReactNativeNodeAPIConfiguration {
-  reactNativeNodeApi?: {
-    scan?: {
-      dependencies?: string[];
-    };
-  };
-}
-
-type PackageJsonWithNodeApi = NormalizedPackageJson &
-  ReactNativeNodeAPIConfiguration;
 
 /**
  * Search upwards from a directory to find a package.json and
@@ -333,9 +347,14 @@ export function findPackageDependencyPaths(
 
   const requireFromRoot = createRequire(path.join(packageRoot, "noop.js"));
 
-  const { dependencies = {}, reactNativeNodeApi } = readPackageSync({
+  const packageJson = readPackageSync({
     cwd: packageRoot,
   }) as PackageJsonWithNodeApi;
+
+  const { dependencies = {} } =
+    PackageJsonDependenciesSchema.parse(packageJson);
+  const { reactNativeNodeApi } =
+    ReactNativeNodeAPIConfigurationSchema.parse(packageJson);
 
   const initialDeps = Object.keys(dependencies).concat(
     reactNativeNodeApi?.scan?.dependencies ?? [],

--- a/packages/host/src/node/path-utils.ts
+++ b/packages/host/src/node/path-utils.ts
@@ -376,6 +376,7 @@ export function findPackageDependencyPaths(
 
     const root = resolvePackageRoot(requireFromRoot, name);
     if (!root) {
+      console.warn(`Cannot find package root from ${fromPath} for ${name}`);
       continue;
     }
 

--- a/packages/host/src/node/path-utils.ts
+++ b/packages/host/src/node/path-utils.ts
@@ -321,6 +321,21 @@ export type PackageJsonDependencies = zod.infer<
 type PackageJsonWithNodeApi = PackageJsonDependencies &
   ReactNativeNodeAPIConfiguration;
 
+export function parseReactNativeNodeAPIConfigurationSchema(
+  packageJson: PackageJsonWithNodeApi,
+): ReactNativeNodeAPIConfiguration {
+  const parsed = ReactNativeNodeAPIConfigurationSchema.safeParse(packageJson);
+
+  if (!parsed.success) {
+    console.warn("Invalid reactNativeNodeApi configuration");
+    console.warn(JSON.stringify(packageJson));
+    console.warn(parsed.error.message);
+    return {};
+  }
+
+  return parsed.data;
+}
+
 export function findPackageConfigurationByPath(
   fromPath: string,
 ): ReactNativeNodeAPIConfiguration {
@@ -331,7 +346,7 @@ export function findPackageConfigurationByPath(
     cwd: packageRoot,
   });
 
-  return ReactNativeNodeAPIConfigurationSchema.parse(packageJson);
+  return parseReactNativeNodeAPIConfigurationSchema(packageJson);
 }
 
 /**
@@ -356,7 +371,7 @@ export function findPackageDependencyPaths(
   const { dependencies = {} } =
     PackageJsonDependenciesSchema.parse(packageJson);
   const { reactNativeNodeApi } =
-    ReactNativeNodeAPIConfigurationSchema.parse(packageJson);
+    parseReactNativeNodeAPIConfigurationSchema(packageJson);
 
   const initialDeps = Object.keys(dependencies).concat(
     reactNativeNodeApi?.scan?.dependencies ?? [],


### PR DESCRIPTION
# Issue
At the moment, we cannot import Node-API dependencies unless they are explicitly declared in package.json #366. However, there are valid use cases where a user installs a package that depends on an Node-API module. For example, it could be an SDK that includes the Node-API module.

Right now, there is only 2 workaround: manually adding that package to dependencies or manually linking. This is far from ideal, as it complicates the migration flow between versions of the dependency that relies on this package.
I see only two potential solutions at the moment: scan the entire `node_modules` directory, or get a “hint” from somewhere about which modules require auto-linking. I consider the first option to be bad, as it requires a lot of resources.

The goal of this PR is to introduce a separate configuration field in `package.json` that allows specifying package names for auto-linking, without interacting with the package manager in any way.

# Things done
- Updated `package-lock.json`
- Added `reactNativeNodeApi` field reading from `package.json` for project and depencies for project

new `package.json` example

```json
{
  "name": "expo-pshenmic-dpp-test",
  "version": "1.0.0",
  "main": "index.ts",
  "scripts": {
    "start": "expo start",
  },
  "dependencies": {
    "moduleA": "^54.0.6",
  },
  "reactNativeNodeApi": {
    "scan": {
      "dependencies": ["moduleA"]
    }
  },
  "devDependencies": {},
  "private": true
}
```

The module maintainers can also set the configuration within the module's package.json file. In this case, the configuration section need not be duplicated in the project's package.json.
