### PR TITLE
ci: pin CMake on macOS weak-node-api tests

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -125,6 +125,12 @@ jobs:
         uses: hendrikmuhs/ccache-action@v1.2
         with:
           key: ${{ github.job }}-${{ runner.os }}
+      # macOS runners ship a newer CMake than the project supports; pin it to match the version used elsewhere in CI
+      - name: Install compatible CMake version
+        if: runner.os == 'macOS'
+        uses: jwlawson/actions-setup-cmake@v2
+        with:
+          cmake-version: ${{ env.CMAKE_VERSION }}
       - run: npm ci
       - run: npm run build
       - name: Prepare weak-node-api


### PR DESCRIPTION
## Why

Follow-up to #374. The `weak-node-api-tests` job runs `cmake` directly on `macos-latest` with **no version pin**, so it picks up the runner's default CMake 4.2.x instead of the project's pinned `4.1.2` — the same drift that broke the `unit-tests` job. This job runs on pushes to `main`, so leaving it unpinned keeps `main` at risk of going red.

## What

- Add a macOS-only `jwlawson/actions-setup-cmake` step to `weak-node-api-tests`, matching the `unit-tests` and `test-macos` jobs.

This PR is labeled `weak-node-api` so the otherwise main-only job runs here and validates the fix before merge.

## Test plan

- [ ] Weak Node-API tests (macos-latest) passes on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)