### PR TITLE
ci: pin CMake on macOS test-ios and test-ferric-apple-triplets

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -168,6 +168,11 @@ jobs:
         with:
           packages: tools platform-tools ndk;${{ env.NDK_VERSION }}
       - run: rustup target add x86_64-linux-android aarch64-linux-android armv7-linux-androideabi i686-linux-android aarch64-apple-ios-sim
+      # macOS runners ship a newer CMake than the project supports; pin it to match the version used elsewhere in CI
+      - name: Install compatible CMake version
+        uses: jwlawson/actions-setup-cmake@v2
+        with:
+          cmake-version: ${{ env.CMAKE_VERSION }}
       - run: npm ci
       - run: npm run bootstrap
         env:
@@ -340,6 +345,11 @@ jobs:
           distribution: "temurin"
       - run: rustup target add x86_64-apple-darwin x86_64-apple-ios aarch64-apple-ios aarch64-apple-ios-sim
       - run: rustup toolchain install nightly --component rust-src
+      # macOS runners ship a newer CMake than the project supports; pin it to match the version used elsewhere in CI
+      - name: Install compatible CMake version
+        uses: jwlawson/actions-setup-cmake@v2
+        with:
+          cmake-version: ${{ env.CMAKE_VERSION }}
       - run: npm ci
       - run: npm run build
       - name: Build weak-node-api for all Apple architectures


### PR DESCRIPTION
## Why

Follow-up to #374 / #375. The first push-to-`main` run in months surfaced that **two more macOS jobs** hit the same CMake 4.2.x FRAMEWORK-vs-HEADERS error, because they build the `weak-node-api` Apple framework but never pinned CMake:

- **Test ferric Apple triplets** — `CMake Error in CMakeLists.txt` on every Apple triplet during `prebuild:build:apple`.
- **Test app (iOS)** — fails downstream: `Expected an XCFramework at .../weak-node-api/build/Release/weak-node-api.xcframework` (never built because the CMake generate step failed).

Both run on pushes to `main`, so they keep `main` red even after #375.

## What

- Add the macOS `jwlawson/actions-setup-cmake` pin (`CMAKE_VERSION` = 4.1.2) to `test-ios` and `test-ferric-apple-triplets`, matching `unit-tests`, `weak-node-api-tests`, and `test-macos`.

This PR is labeled `Apple 🍎` and `Ferric 🦀` so both jobs run here and validate before merge.

## Test plan

- [ ] Test app (iOS) passes on this PR.
- [ ] Test ferric Apple triplets passes on this PR.

Interim workaround; the proper CMakeLists fix (so no pins are needed anywhere) is tracked in #376.

🤖 Generated with [Claude Code](https://claude.com/claude-code)