### PR TITLE
Fail fast when bootstrapping workspaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "prettier:check": "prettier --experimental-cli --check .",
     "prettier:write": "prettier --experimental-cli --write .",
     "test": "npm test --workspace react-native-node-api --workspace cmake-rn --workspace gyp-to-cmake --workspace node-addon-examples",
-    "bootstrap": "node --run build && npm run bootstrap --workspaces --if-present",
+    "bootstrap": "node --run build && node scripts/bootstrap.ts",
     "changeset": "changeset",
     "release": "changeset publish",
     "prerelease": "node --run build && npm run prerelease --workspaces --if-present && node --run publint",

--- a/scripts/bootstrap.ts
+++ b/scripts/bootstrap.ts
@@ -1,0 +1,68 @@
+import path from "node:path";
+import assert from "node:assert/strict";
+import cp from "node:child_process";
+import fs from "node:fs";
+
+// Bootstrap every workspace sequentially, failing fast on the first error.
+//
+// We deliberately don't use "npm run bootstrap --workspaces --if-present" here:
+// npm keeps iterating the remaining workspaces even after one of them fails and
+// only surfaces a non-zero exit code once they've all run. Because later
+// workspaces depend on artifacts produced by earlier ones (e.g. the
+// weak-node-api xcframework consumed by node-addon-examples, node-tests and
+// ferric-example), a failure in an early workspace produces a cascade of
+// confusing secondary errors, hiding the actual root cause. Iterating ourselves
+// lets us stop at the first failing workspace.
+
+const rootDir = path.resolve(import.meta.dirname, "..");
+
+function readPackageJson(packageDir: string): Record<string, unknown> {
+  const contents = fs.readFileSync(
+    path.join(packageDir, "package.json"),
+    "utf8",
+  );
+  const parsed = JSON.parse(contents) as unknown;
+  assert(
+    typeof parsed === "object" && parsed !== null,
+    `Expected an object in ${packageDir}/package.json`,
+  );
+  return parsed as Record<string, unknown>;
+}
+
+const rootPackage = readPackageJson(rootDir);
+assert(
+  Array.isArray(rootPackage.workspaces),
+  "Expected a 'workspaces' array in the root package.json",
+);
+
+for (const workspace of rootPackage.workspaces) {
+  assert(typeof workspace === "string");
+  // The workspaces are declared as concrete directories – reject globs rather
+  // than silently skipping workspaces they were meant to expand to.
+  assert(
+    !workspace.includes("*"),
+    `Glob workspace patterns are not supported ('${workspace}')`,
+  );
+
+  const workspaceDir = path.resolve(rootDir, workspace);
+  const { name, scripts } = readPackageJson(workspaceDir);
+  assert(typeof name === "string");
+
+  const hasBootstrap =
+    typeof scripts === "object" && scripts !== null && "bootstrap" in scripts;
+  if (!hasBootstrap) {
+    continue;
+  }
+
+  console.log(`Bootstrapping '${name}'`);
+  const { status } = cp.spawnSync(
+    "npm",
+    ["run", "bootstrap", "--workspace", name],
+    { stdio: "inherit" },
+  );
+  assert.equal(
+    status,
+    0,
+    `Bootstrapping '${name}' failed (status = ${status})`,
+  );
+}


### PR DESCRIPTION
## Problem

A `npm run bootstrap` step in CI (e.g. [this Test app (iOS) run](https://github.com/callstackincubator/react-native-node-api/actions/runs/29610484155/job/87983718523)) doesn't stop on the first real error. Instead it continues and fails a series of *secondary* commands that only fail *because* an earlier command failed, making the log noisy and the real root cause hard to spot.

## Root cause

The root `bootstrap` script was:

```
node --run build && npm run bootstrap --workspaces --if-present
```

npm's `--workspaces` iteration is **not fail-fast**. When one workspace's `bootstrap` script exits non-zero, npm keeps running the `bootstrap` script for every remaining workspace and only surfaces a non-zero exit code once they've *all* run.

In the linked run, the actual first failure is `weak-node-api`'s bootstrap — a CMake configuration error prevents the `weak-node-api.xcframework` from being produced:

```
> weak-node-api@0.1.1 bootstrap
...
CMake Error in CMakeLists.txt:
  The file set "HEADERS", of type "HEADERS", is incompatible with the "FRAMEWORK" target "weak-node-api".
...
ERROR Running 'cmake' failed (code = 1)
npm error workspace weak-node-api@0.1.1
```

That exit code *is* propagated correctly, but because npm doesn't fail fast, the workspaces that consume the xcframework then run and fail with confusing downstream errors:

- `node-addon-examples` → `Expected an XCFramework at .../weak-node-api/build/Release/weak-node-api.xcframework`
- `node-tests` → same missing-xcframework assertion
- `ferric-example` → `No matching slice found in weak-node-api.xcframework for target aarch64-apple-ios-sim`

So the run "doesn't fail on the first error" — it fails three more times on commands that depend on the first one having succeeded, and the genuine root cause (the CMake error in `weak-node-api`) is buried in the middle of the log.

> Note: the underlying CMake `HEADERS`/`FRAMEWORK` incompatibility in `weak-node-api` is a separate build issue and is intentionally **not** addressed here — this PR only fixes the error-propagation/fail-fast behavior so that such a failure is surfaced clearly instead of triggering a cascade.

## Fix

Replace the non-fail-fast `--workspaces` iteration with a small `scripts/bootstrap.ts` that:

- iterates the workspaces in their **declared order** (which is the build order — `weak-node-api` before its consumers),
- runs `npm run bootstrap --workspace <name>` for each workspace that has a `bootstrap` script (preserving the `--if-present` semantics),
- and **stops at the first workspace that fails**, propagating its exit code.

This mirrors the existing `scripts/run-in-published.ts` pattern already used in the repo.

## Verification

Reproduced npm's non-fail-fast behavior with a 3-workspace fixture (`a` ok, `b` fails, `c` ok): `c` still ran after `b` failed, matching the CI log. Ran the new `scripts/bootstrap.ts` against the same fixture:

- `b` fails → `c` is **not** run, script exits `1` immediately.
- all-success case → every workspace with a `bootstrap` script runs, workspaces without one are skipped, script exits `0`.

Also confirmed the generated bootstrap plan against the real repo matches the previous behavior exactly (`weak-node-api` → `host` → `node-addon-examples` → `node-tests` → `ferric-example`, with script-less workspaces skipped).

## Follow-up (not in this PR)

The `prerelease` root script uses the same non-fail-fast pattern (`npm run prerelease --workspaces --if-present`) and would benefit from the same treatment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MFfJiaaqbgMqnrNUB6e76m

---
_Generated by [Claude Code](https://claude.ai/code/session_01MFfJiaaqbgMqnrNUB6e76m)_