### PR TITLE
ci: stop running test-android on main (self-hosted runner offline)

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -234,7 +234,11 @@ jobs:
         env:
           MOCHA_REMOTE_CONTEXT: allTests
   test-android:
-    if: github.ref == 'refs/heads/main' || contains(github.event.pull_request.labels.*.name, 'Android 🤖')
+    # Temporarily gated to labeled PRs only: the ubuntu-self-hosted runner is
+    # offline, so running this on main pushes leaves the job queued forever and
+    # blocks the whole Check run from completing. Re-enable on main once the
+    # self-hosted runner is back. Tracked in #379.
+    if: contains(github.event.pull_request.labels.*.name, 'Android 🤖')
     name: Test app (Android)
     runs-on: ubuntu-self-hosted
     steps:


### PR DESCRIPTION
## Why

The `test-android` job runs on `ubuntu-self-hosted`, which is currently **offline**. On pushes to `main` the job sits in `queued` indefinitely (observed 6h+), so the `Check` run never completes and `main` can never report green. It's the sole remaining blocker after #374 / #375 / #377 fixed the CMake failures.

## What

- Gate `test-android` to PRs labeled `Android 🤖` only, removing it from `main` pushes (same pattern as `test-macos`).

This is a temporary stopgap. Re-enabling on `main` — once the self-hosted runner is back, or after migrating to a GitHub-hosted `ubuntu-latest` runner with KVM — is tracked in #379.

## Test plan

- [x] Not runnable here (this PR is unlabeled, so `test-android` is skipped by design — that's the point).
- [ ] After merge, the `Check` run on `main` completes without hanging on Android.

🤖 Generated with [Claude Code](https://claude.com/claude-code)