### PR TITLE
Split public header packaging between framework and file set

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -92,12 +92,6 @@ jobs:
         with:
           packages: tools platform-tools ndk;${{ env.NDK_VERSION }}
       - run: rustup target add x86_64-linux-android aarch64-linux-android armv7-linux-androideabi i686-linux-android aarch64-apple-ios-sim
-      # macOS runners ship a newer CMake than the project supports; pin it to match the version used elsewhere in CI
-      - name: Install compatible CMake version
-        if: runner.os == 'macOS'
-        uses: jwlawson/actions-setup-cmake@v2
-        with:
-          cmake-version: ${{ env.CMAKE_VERSION }}
       - run: npm ci
       - run: npm run bootstrap
       - run: npm test
@@ -125,12 +119,6 @@ jobs:
         uses: hendrikmuhs/ccache-action@v1.2
         with:
           key: ${{ github.job }}-${{ runner.os }}
-      # macOS runners ship a newer CMake than the project supports; pin it to match the version used elsewhere in CI
-      - name: Install compatible CMake version
-        if: runner.os == 'macOS'
-        uses: jwlawson/actions-setup-cmake@v2
-        with:
-          cmake-version: ${{ env.CMAKE_VERSION }}
       - run: npm ci
       - run: npm run build
       - name: Prepare weak-node-api
@@ -168,11 +156,6 @@ jobs:
         with:
           packages: tools platform-tools ndk;${{ env.NDK_VERSION }}
       - run: rustup target add x86_64-linux-android aarch64-linux-android armv7-linux-androideabi i686-linux-android aarch64-apple-ios-sim
-      # macOS runners ship a newer CMake than the project supports; pin it to match the version used elsewhere in CI
-      - name: Install compatible CMake version
-        uses: jwlawson/actions-setup-cmake@v2
-        with:
-          cmake-version: ${{ env.CMAKE_VERSION }}
       - run: npm ci
       - run: npm run bootstrap
         env:
@@ -209,10 +192,6 @@ jobs:
         with:
           java-version: "17"
           distribution: "temurin"
-      - name: Install compatible CMake version
-        uses: jwlawson/actions-setup-cmake@v2
-        with:
-          cmake-version: ${{ env.CMAKE_VERSION }}
       - run: rustup target add x86_64-apple-darwin
       - run: npm ci
       - run: npm run bootstrap
@@ -345,11 +324,6 @@ jobs:
           distribution: "temurin"
       - run: rustup target add x86_64-apple-darwin x86_64-apple-ios aarch64-apple-ios aarch64-apple-ios-sim
       - run: rustup toolchain install nightly --component rust-src
-      # macOS runners ship a newer CMake than the project supports; pin it to match the version used elsewhere in CI
-      - name: Install compatible CMake version
-        uses: jwlawson/actions-setup-cmake@v2
-        with:
-          cmake-version: ${{ env.CMAKE_VERSION }}
       - run: npm ci
       - run: npm run build
       - name: Build weak-node-api for all Apple architectures

--- a/packages/weak-node-api/CMakeLists.txt
+++ b/packages/weak-node-api/CMakeLists.txt
@@ -10,24 +10,32 @@ add_library(${PROJECT_NAME} SHARED)
 set(INCLUDE_DIR "include")
 set(GENERATED_SOURCE_DIR "generated")
 
+set(PUBLIC_HEADER_FILES
+  ${GENERATED_SOURCE_DIR}/weak_node_api.hpp
+  ${GENERATED_SOURCE_DIR}/NodeApiHost.hpp
+  ${INCLUDE_DIR}/js_native_api_types.h
+  ${INCLUDE_DIR}/js_native_api.h
+  ${INCLUDE_DIR}/node_api_types.h
+  ${INCLUDE_DIR}/node_api.h
+)
+
 target_sources(${PROJECT_NAME}
   PUBLIC
     ${GENERATED_SOURCE_DIR}/weak_node_api.cpp
-  PUBLIC FILE_SET HEADERS
-  BASE_DIRS ${GENERATED_SOURCE_DIR} ${INCLUDE_DIR} FILES
-    ${GENERATED_SOURCE_DIR}/weak_node_api.hpp
-    ${GENERATED_SOURCE_DIR}/NodeApiHost.hpp
-    ${INCLUDE_DIR}/js_native_api_types.h
-    ${INCLUDE_DIR}/js_native_api.h
-    ${INCLUDE_DIR}/node_api_types.h
-    ${INCLUDE_DIR}/node_api.h
 )
 
-get_target_property(PUBLIC_HEADER_FILES ${PROJECT_NAME} HEADER_SET)
+# Expose the public headers to consumers within the build tree (e.g. the tests)
+# regardless of how they are packaged below.
+target_include_directories(${PROJECT_NAME}
+  PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/${GENERATED_SOURCE_DIR}>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/${INCLUDE_DIR}>
+)
 
 # Stripping the prefix from the library name
 # to make sure the name of the XCFramework will match the name of the library
 if(APPLE)
+  # Frameworks ship their public headers via the PUBLIC_HEADER property.
   set_target_properties(${PROJECT_NAME} PROPERTIES
     FRAMEWORK TRUE
     MACOSX_FRAMEWORK_IDENTIFIER com.callstack.${PROJECT_NAME}
@@ -36,6 +44,13 @@ if(APPLE)
     VERSION ${PACKAGE_VERSION}
     XCODE_ATTRIBUTE_SKIP_INSTALL NO
     PUBLIC_HEADER "${PUBLIC_HEADER_FILES}"
+  )
+else()
+  # Elsewhere, ship the public headers via a HEADERS file set for install packaging.
+  target_sources(${PROJECT_NAME}
+    PUBLIC FILE_SET HEADERS
+    BASE_DIRS ${GENERATED_SOURCE_DIR} ${INCLUDE_DIR} FILES
+      ${PUBLIC_HEADER_FILES}
   )
 endif()
 


### PR DESCRIPTION
## Context

CMake 4.2 (the current default on GitHub's `macos-latest` runners) rejects the `weak-node-api` build with:

```
CMake Error in CMakeLists.txt:
  The file set "HEADERS", of type "HEADERS", is incompatible with the
  "FRAMEWORK" target "weak-node-api".
```

`packages/weak-node-api/CMakeLists.txt` attached the public headers to the target **two** ways at once — a modern `FILE_SET HEADERS` *and* the framework's legacy `PUBLIC_HEADER` (inside the `if(APPLE)` block that also sets `FRAMEWORK TRUE`). CMake 4.2 makes a `HEADERS` file set incompatible with a `FRAMEWORK` target, so the Apple build now errors.

As a temporary unblock, #374 / #375 / #377 pinned CMake to `4.1.2` on five macOS jobs. This fixes the root cause and removes those pins.

## Changes

**`packages/weak-node-api/CMakeLists.txt`**
- Hoisted the header list into a `PUBLIC_HEADER_FILES` variable (previously read back from the target's `HEADER_SET` property).
- On Apple, ship the public headers via the framework's `PUBLIC_HEADER` property only — no `FILE_SET HEADERS` on the framework target. The header list is identical to before, so XCFramework packaging is unchanged.
- On other platforms, keep the `HEADERS` file set for install packaging.
- Added an explicit `target_include_directories(... $<BUILD_INTERFACE:...>)` so in-tree consumers (the C++ tests, which `#include <weak_node_api.hpp>`) still get the include paths the file set used to supply implicitly.

**`.github/workflows/check.yml`**
- Reverted the macOS CMake `4.1.2` pin from all five jobs: `unit-tests`, `weak-node-api-tests`, `test-ios`, `test-macos`, `test-ferric-apple-triplets`.
- Kept the `CMAKE_VERSION` env var — it still selects the Android SDK `cmake` package in `test-android`, unrelated to this issue.

## Verification

Validated the non-Apple path end-to-end locally: generated the sources, then `cmake -S . -B build-tests -DBUILD_TESTS=ON` → build → `ctest`, all passing — including the test's `#include <weak_node_api.hpp>`, confirming the new `target_include_directories` propagates includes to consumers.

The Apple `.framework` / XCFramework build is exercised by this PR's macOS CI (hence the `weak-node-api` / `Apple 🍎` / `Ferric 🦀` labels). All four Apple framework-building jobs — `Unit tests (macos-latest)`, `Weak Node-API tests (macos-latest)`, `Test app (iOS)`, and `Test ferric Apple triplets` — pass on the runner's default CMake, confirming the pin is no longer needed.

> **Note:** `test-macos` (the `MacOS 💻` label) is intentionally *not* applied. It currently fails to build the React Native macOS test app due to an unrelated `fmt` consteval error in RN's own C++ (Yoga / logger), which has nothing to do with this change. That's tracked separately.

## Acceptance criteria

- [x] `weak-node-api` configures and builds on macOS with the runner's default CMake (no version pin) — validated by CI.
- [x] Reverted the macOS CMake pin from all affected jobs.
- [x] macOS `.framework` / XCFramework still ships the correct public headers (identical `PUBLIC_HEADER` list).

Closes #376

🤖 Generated with [Claude Code](https://claude.com/claude-code)