### PR TITLE
fix(macos-test-app): get the label-gated `test-macos` job green

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -222,7 +222,8 @@ jobs:
         run: npx react-native bundle --entry-file index.js --platform macos --dev false --minify false --bundle-output dist/main.macos.jsbundle --assets-dest dist/res
         working-directory: apps/macos-test-app
       - name: Build test app
-        run: xcodebuild archive -workspace MacOSTestApp.xcworkspace -configuration Release -scheme MacOSTestApp-macOS -destination generic/platform="macOS" -archivePath ./build/macos-test-app.xcarchive | xcbeautify
+        # pipefail so an xcodebuild failure is not masked by xcbeautify's exit code
+        run: set -o pipefail && xcodebuild archive -workspace MacOSTestApp.xcworkspace -configuration Release -scheme MacOSTestApp-macOS -destination generic/platform="macOS" -archivePath ./build/macos-test-app.xcarchive | xcbeautify
         working-directory: apps/macos-test-app/macos
       - name: Run test app
         run: npx mocha-remote --exit-on-error -- macos/build/macos-test-app.xcarchive/Products/Applications/MacOSTestApp.app/Contents/MacOS/MacOSTestApp

--- a/apps/test-app/metro.config.js
+++ b/apps/test-app/metro.config.js
@@ -12,11 +12,7 @@ const config = makeMetroConfig({
 });
 
 if (config.projectRoot.endsWith("macos-test-app")) {
-  // This patch is needed to locate packages in the monorepo from the MacOS app
-  // which is intentionally kept outside of the workspaces configuration to prevent
-  // duplicate react-native version and pollution of the package lock.
   const path = require("node:path");
-  config.watchFolders.push(path.resolve(__dirname, "../.."));
 
   // Resolve workspace packages (and the specifiers the babel plugin rewrites
   // their `*.node` requires to) from this app's own node_modules, independent of

--- a/apps/test-app/metro.config.js
+++ b/apps/test-app/metro.config.js
@@ -18,17 +18,9 @@ if (config.projectRoot.endsWith("macos-test-app")) {
   const path = require("node:path");
   config.watchFolders.push(path.resolve(__dirname, "../.."));
 
-  // The babel plugin rewrites `require("something.node")` inside the workspace
-  // packages (e.g. packages/ferric-example/ferric_example.js) into
-  // `require("react-native-node-api").requireNodeAddon(...)`. Those files live
-  // outside this app, so Metro resolves the bare `react-native-node-api` (and
-  // sibling workspace packages) by walking up from the package directory. Under
-  // npm's hoisted workspaces that specifier happens to sit in the repo-root
-  // node_modules, but under pnpm's isolated node_modules it does not, so the
-  // rewritten require fails to resolve. This app installs the workspace packages
-  // into its own node_modules (via `npm install` of `file:` deps), so add that
-  // directory as a global module-resolution path to make resolution independent
-  // of the root package manager's hoisting layout.
+  // Resolve workspace packages (and the specifiers the babel plugin rewrites
+  // their `*.node` requires to) from this app's own node_modules, independent of
+  // the root package manager's hoisting layout.
   config.resolver = config.resolver || {};
   config.resolver.nodeModulesPaths = [
     ...(config.resolver.nodeModulesPaths || []),

--- a/apps/test-app/metro.config.js
+++ b/apps/test-app/metro.config.js
@@ -17,6 +17,23 @@ if (config.projectRoot.endsWith("macos-test-app")) {
   // duplicate react-native version and pollution of the package lock.
   const path = require("node:path");
   config.watchFolders.push(path.resolve(__dirname, "../.."));
+
+  // The babel plugin rewrites `require("something.node")` inside the workspace
+  // packages (e.g. packages/ferric-example/ferric_example.js) into
+  // `require("react-native-node-api").requireNodeAddon(...)`. Those files live
+  // outside this app, so Metro resolves the bare `react-native-node-api` (and
+  // sibling workspace packages) by walking up from the package directory. Under
+  // npm's hoisted workspaces that specifier happens to sit in the repo-root
+  // node_modules, but under pnpm's isolated node_modules it does not, so the
+  // rewritten require fails to resolve. This app installs the workspace packages
+  // into its own node_modules (via `npm install` of `file:` deps), so add that
+  // directory as a global module-resolution path to make resolution independent
+  // of the root package manager's hoisting layout.
+  config.resolver = config.resolver || {};
+  config.resolver.nodeModulesPaths = [
+    ...(config.resolver.nodeModulesPaths || []),
+    path.resolve(__dirname, "node_modules"),
+  ];
 }
 
 module.exports = config;

--- a/apps/test-app/metro.config.js
+++ b/apps/test-app/metro.config.js
@@ -12,7 +12,11 @@ const config = makeMetroConfig({
 });
 
 if (config.projectRoot.endsWith("macos-test-app")) {
+  // This patch is needed to locate packages in the monorepo from the MacOS app
+  // which is intentionally kept outside of the workspaces configuration to prevent
+  // duplicate react-native version and pollution of the package lock.
   const path = require("node:path");
+  config.watchFolders.push(path.resolve(__dirname, "../.."));
 
   // Resolve workspace packages (and the specifiers the babel plugin rewrites
   // their `*.node` requires to) from this app's own node_modules, independent of

--- a/scripts/init-macos-test-app.ts
+++ b/scripts/init-macos-test-app.ts
@@ -88,10 +88,7 @@ async function patchPackageJson() {
 
   const transferredDependencies = new Set([
     "@rnx-kit/metro-config",
-    // `mocha-remote-server` (pulled in by `mocha-remote-cli`) requires `mocha` at
-    // runtime. It resolves fine in the workspace apps via hoisting, but this app
-    // is installed standalone, so `mocha` must be an explicit dependency here or
-    // the "Run test app" step fails with "Cannot find module 'mocha'".
+    // Needed by mocha-remote-server at runtime (not hoisted for this standalone app).
     "mocha",
     "mocha-remote-cli",
     "mocha-remote-react-native",
@@ -176,16 +173,9 @@ async function patchPodfile() {
       "react_native_post_install(installer)",
       `react_native_post_install(installer, '../node_modules/react-native-macos')
 
-    # Xcode 26.4 ships Apple clang 21, which enforces C++20 'consteval' more
-    # strictly and rejects fmt 11.0.2's FMT_STRING() usages with "call to
-    # consteval function ... is not a constant expression" (in fmt itself, Yoga
-    # and React-logger). React Native 0.81 bundles fmt 11.0.2 and the upstream
-    # fix (fmt 12.1.0) only reached React Native >= 0.83.9, so force fmt's
-    # compile-time (consteval) format-string checking off — it falls back to
-    # runtime validation, which compiles cleanly. Patch the vendored fmt headers
-    # directly (setting FMT_USE_CONSTEVAL to 0) rather than via a build-settings
-    # define, because the define does not reliably reach every fmt-consuming
-    # translation unit.
+    # Disable fmt's consteval format-string checks, which Xcode 26.4 / clang 21
+    # reject in RN 0.81's bundled fmt 11.0.2. Removable once react-native-macos
+    # ships a release carrying fmt >= 12.1.
     fmt_root = File.join(installer.sandbox.root.to_s, 'fmt')
     Dir.glob(File.join(fmt_root, '**', '*.h')).each do |header|
       contents = File.read(header)

--- a/scripts/init-macos-test-app.ts
+++ b/scripts/init-macos-test-app.ts
@@ -169,7 +169,24 @@ async function patchPodfile() {
     ],
     [
       "react_native_post_install(installer)",
-      "react_native_post_install(installer, '../node_modules/react-native-macos')",
+      `react_native_post_install(installer, '../node_modules/react-native-macos')
+
+    # Xcode 26.4 ships Apple clang 21, which enforces C++20 'consteval' more
+    # strictly and rejects fmt 11.0.2's FMT_STRING() usages with "call to
+    # consteval function ... is not a constant expression" (in fmt itself, Yoga
+    # and React-logger). React Native 0.81 bundles fmt 11.0.2 and the upstream
+    # fix (fmt 12.1.0) only reached React Native >= 0.83.9, so disable fmt's
+    # compile-time (consteval) format-string checking across all pods. fmt guards
+    # this define with '#ifndef FMT_USE_CONSTEVAL', so pre-defining it wins and it
+    # falls back to runtime format-string validation, which compiles cleanly.
+    installer.pods_project.targets.each do |target|
+      target.build_configurations.each do |build_config|
+        definitions = build_config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] || ['$(inherited)']
+        definitions = [definitions] unless definitions.is_a?(Array)
+        definitions << 'FMT_USE_CONSTEVAL=0' unless definitions.include?('FMT_USE_CONSTEVAL=0')
+        build_config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] = definitions
+      end
+    end`,
     ],
   ];
 

--- a/scripts/init-macos-test-app.ts
+++ b/scripts/init-macos-test-app.ts
@@ -88,6 +88,11 @@ async function patchPackageJson() {
 
   const transferredDependencies = new Set([
     "@rnx-kit/metro-config",
+    // `mocha-remote-server` (pulled in by `mocha-remote-cli`) requires `mocha` at
+    // runtime. It resolves fine in the workspace apps via hoisting, but this app
+    // is installed standalone, so `mocha` must be an explicit dependency here or
+    // the "Run test app" step fails with "Cannot find module 'mocha'".
+    "mocha",
     "mocha-remote-cli",
     "mocha-remote-react-native",
   ]);
@@ -175,17 +180,18 @@ async function patchPodfile() {
     # strictly and rejects fmt 11.0.2's FMT_STRING() usages with "call to
     # consteval function ... is not a constant expression" (in fmt itself, Yoga
     # and React-logger). React Native 0.81 bundles fmt 11.0.2 and the upstream
-    # fix (fmt 12.1.0) only reached React Native >= 0.83.9, so disable fmt's
-    # compile-time (consteval) format-string checking across all pods. fmt guards
-    # this define with '#ifndef FMT_USE_CONSTEVAL', so pre-defining it wins and it
-    # falls back to runtime format-string validation, which compiles cleanly.
-    installer.pods_project.targets.each do |target|
-      target.build_configurations.each do |build_config|
-        definitions = build_config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] || ['$(inherited)']
-        definitions = [definitions] unless definitions.is_a?(Array)
-        definitions << 'FMT_USE_CONSTEVAL=0' unless definitions.include?('FMT_USE_CONSTEVAL=0')
-        build_config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] = definitions
-      end
+    # fix (fmt 12.1.0) only reached React Native >= 0.83.9, so force fmt's
+    # compile-time (consteval) format-string checking off — it falls back to
+    # runtime validation, which compiles cleanly. Patch the vendored fmt headers
+    # directly (setting FMT_USE_CONSTEVAL to 0) rather than via a build-settings
+    # define, because the define does not reliably reach every fmt-consuming
+    # translation unit.
+    fmt_root = File.join(installer.sandbox.root.to_s, 'fmt')
+    Dir.glob(File.join(fmt_root, '**', '*.h')).each do |header|
+      contents = File.read(header)
+      next unless contents.include?('FMT_USE_CONSTEVAL')
+      patched = contents.gsub(/#\\s*define\\s+FMT_USE_CONSTEVAL\\s+1\\b/, '#define FMT_USE_CONSTEVAL 0')
+      File.write(header, patched) if patched != contents
     end`,
     ],
   ];

--- a/scripts/init-macos-test-app.ts
+++ b/scripts/init-macos-test-app.ts
@@ -5,7 +5,7 @@ import path from "node:path";
 import { readPackage } from "read-pkg";
 
 const REACT_NATIVE_VERSION = "0.81.5";
-const REACT_NATIVE_MACOS_VERSION = "0.81.1";
+const REACT_NATIVE_MACOS_VERSION = "0.81.8";
 const REACT_VERSION = "^19.1.4";
 
 const ROOT_PATH = path.join(import.meta.dirname, "..");
@@ -171,18 +171,7 @@ async function patchPodfile() {
     ],
     [
       "react_native_post_install(installer)",
-      `react_native_post_install(installer, '../node_modules/react-native-macos')
-
-    # Disable fmt's consteval format-string checks, which Xcode 26.4 / clang 21
-    # reject in RN 0.81's bundled fmt 11.0.2. Removable once react-native-macos
-    # ships a release carrying fmt >= 12.1.
-    fmt_root = File.join(installer.sandbox.root.to_s, 'fmt')
-    Dir.glob(File.join(fmt_root, '**', '*.h')).each do |header|
-      contents = File.read(header)
-      next unless contents.include?('FMT_USE_CONSTEVAL')
-      patched = contents.gsub(/#\\s*define\\s+FMT_USE_CONSTEVAL\\s+1\\b/, '#define FMT_USE_CONSTEVAL 0')
-      File.write(header, patched) if patched != contents
-    end`,
+      "react_native_post_install(installer, '../node_modules/react-native-macos')",
     ],
   ];
 

--- a/scripts/init-macos-test-app.ts
+++ b/scripts/init-macos-test-app.ts
@@ -4,7 +4,9 @@ import fs from "node:fs";
 import path from "node:path";
 import { readPackage } from "read-pkg";
 
-const REACT_NATIVE_VERSION = "0.81.5";
+// react-native-macos peer-pins an exact react-native core version
+// (react-native-macos 0.81.8 -> react-native 0.81.6); keep these two in lockstep.
+const REACT_NATIVE_VERSION = "0.81.6";
 const REACT_NATIVE_MACOS_VERSION = "0.81.8";
 const REACT_VERSION = "^19.1.4";
 


### PR DESCRIPTION
## Goal

Get the `test-macos` job (**Test app (macOS)**, gated behind the `MacOS 💻` label) green again. It had been red for a couple of months. ✅ **It is now green** — verified end-to-end on a real macOS runner (scaffold → `pod install` → `react-native bundle` → `xcodebuild archive` → run tests): [run #1096](https://github.com/callstackincubator/react-native-node-api/actions/runs/29954573824).

> Based on the pnpm branch (`claude/migrate-pnpm-workspaces-qp0m9t`, #381) so all failure modes are reproducible/verifiable in a single run. Retarget to `main` once #381 lands. Changes are confined to the macOS test-app path.

Three issues had to be fixed; the job died at whichever came first.

## 1. Metro bundle couldn't resolve `react-native-node-api`

```
error Unable to resolve module react-native-node-api from packages/ferric-example/ferric_example.js
```

The babel plugin **does** rewrite `require("./ferric_example.node")` → `require("react-native-node-api").requireNodeAddon(...)`. The failure is resolving the resulting bare specifier: `ferric_example.js` lives in a workspace package **outside** the (intentionally non-workspace) macOS app, so Metro resolves it by walking up from `packages/ferric-example`. Under npm's hoisted workspaces that specifier happened to sit in the repo-root `node_modules`; under **pnpm's isolated `node_modules` it doesn't**.

**Fix** (`apps/test-app/metro.config.js`, macOS-only block): add the app's own `node_modules` — where its `file:` workspace deps are installed by `npm install` — to Metro's `resolver.nodeModulesPaths`, making resolution independent of the root package manager's hoisting layout.

## 2. Native build failed on `fmt` `consteval`

```
call to consteval function 'fmt::basic_format_string<...>' is not a constant expression
```

GitHub's `macos-latest` runner now ships **Xcode 26.4 / Apple clang 21**, which enforces C++20 `consteval` strictly and rejects the **fmt 11.0.2** that react-native-macos 0.81.1 vendored.

**Fix** (`scripts/init-macos-test-app.ts`): bump the scaffolded versions so the fix comes from upstream instead of a local patch — **`react-native-macos` 0.81.1 → 0.81.8** (its `fmt.podspec` moves fmt 11.0.2 → **12.1.0**, verified at the tag), and **`react-native` 0.81.5 → 0.81.6** because react-native-macos peer-pins an exact core version (0.81.8 → 0.81.6). The two are now kept in lockstep with a comment noting the coupling. No Podfile/header patch needed.

## 3. "Run test app" couldn't find `mocha`

```
Error: Cannot find module 'mocha'
```

`mocha-remote-server` requires `mocha` at runtime. It resolves via hoisting in the workspace apps, but the standalone macOS app must depend on it explicitly.

**Fix** (`scripts/init-macos-test-app.ts`): add `mocha` to the dependencies transferred from `apps/test-app`.

## Also

- `.github/workflows/check.yml`: added `set -o pipefail` to the **Build test app** step so an `xcodebuild` failure is no longer masked by `xcbeautify`'s exit code.

## Result

All checks green on the PR: `Lint`, `Unit tests (ubuntu/windows/macos-latest)`, and the label-gated **Test app (macOS)** — with the native build fixed by an upstream version bump rather than a compiler workaround.

🤖 Generated with [Claude Code](https://claude.com/claude-code)