### PR TITLE
fix(node-tests): declare `assert` dependency, fail bundling on unresolved imports

### DIFF
--- a/packages/node-tests/package.json
+++ b/packages/node-tests/package.json
@@ -26,6 +26,7 @@
     "bootstrap": "node --run copy-tests && node --run gyp-to-cmake && node --run build-tests && node --run bundle && node --run generate-entrypoint"
   },
   "devDependencies": {
+    "assert": "^2.1.0",
     "cmake-rn": "workspace:*",
     "gyp-to-cmake": "workspace:*",
     "react-native-node-api": "workspace:*",

--- a/packages/node-tests/rolldown.config.mts
+++ b/packages/node-tests/rolldown.config.mts
@@ -23,6 +23,24 @@ function readGypTargetNames(gypFilePath: string): string[] {
   });
 }
 
+/**
+ * Fail the build on unresolved imports instead of emitting a warning:
+ * Anything the bundle can't resolve (besides the addons declared as external)
+ * would otherwise only fail at runtime on device, where Metro's runtime require
+ * masks the underlying error.
+ */
+function failOnUnresolvedImports(
+  warning: Parameters<NonNullable<RolldownOptions["onwarn"]>>[0],
+  defaultHandler: Parameters<NonNullable<RolldownOptions["onwarn"]>>[1],
+) {
+  if (warning.code === "UNRESOLVED_IMPORT") {
+    throw new Error(
+      `Unresolved import: ${warning.message} - add the package as a dependency of @react-native-node-api/node-tests`,
+    );
+  }
+  defaultHandler(warning);
+}
+
 function testSuiteConfig(suitePath: string): RolldownOptions[] {
   const testFiles = fs.globSync("*.js", {
     cwd: suitePath,
@@ -32,6 +50,7 @@ function testSuiteConfig(suitePath: string): RolldownOptions[] {
   const targetNames = readGypTargetNames(gypFilePath);
   return testFiles.map((testFile) => ({
     input: path.join(suitePath, testFile),
+    onwarn: failOnUnresolvedImports,
     output: {
       file: path.join(suitePath, path.basename(testFile, ".js") + ".bundle.js"),
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -299,6 +299,9 @@ importers:
 
   packages/node-tests:
     devDependencies:
+      assert:
+        specifier: ^2.1.0
+        version: 2.1.0
       cmake-rn:
         specifier: workspace:*
         version: link:../cmake-rn


### PR DESCRIPTION
Fixes the single failing iOS test on the pnpm-migration branch:

```
Node Tests › js-native-api › 2_function_arguments › test › default
ERROR test.titlePath(...).forEach is not a function
```

## The real error (behind the mask)

The `2_function_arguments` test from nodejs/node calls `require('assert')`. Under **npm workspaces** (main), the `assert@2.1.0` ponyfill declared by `node-addon-examples` was hoisted to the root `node_modules`, where node-tests' rolldown bundle step resolved it as a **phantom dependency** and inlined it into `test.bundle.js`. Under **pnpm's strict layout** the package is no longer reachable from `packages/node-tests`, so rolldown emitted only a warning (`UNRESOLVED_IMPORT … treating it as an external dependency`) and kept a runtime `__require("assert")` in the bundle. Metro bundles that fine (it's not a statically analyzable require), but it throws at runtime on device when the test body runs — the real error behind the mask.

Verified locally: regenerating the bundle on the base branch reproduces the unresolved-import warning and the runtime `__require("assert")`; with this fix the bundle inlines `assert` (2 kB → 153 kB) and the bundled test executes end-to-end against a stubbed addon.

The rest of the pnpm chain checks out: with the built addon in place, both the babel plugin (bundle-time) and the link phase (`findNodeApiModulePathsByDependency` + `getLibraryName` from `apps/test-app`) compute the identical library name `node-tests--2_function_arguments` under pnpm's symlinked `node_modules`, so discovery/copying is not affected.

## The mask itself (upstream, not fixed here)

`test.titlePath(...).forEach is not a function` is a secondary crash in mocha-remote-server's failure formatter, reproducible in isolation: `flatted.parse` with mocha-remote's `$$`-reviver captures an unresolved reference for `$$titlePath` whenever the fail-event payload contains shared string references (which real payloads always do — `parent.$$fullTitle` shares strings with the title path), so `titlePath()` returns a non-array and mocha's `Base` reporter throws while printing the failure. Any failing on-device test currently gets masked this way — worth an upstream mocha-remote issue, but out of scope here.

## Changes

- `packages/node-tests/package.json`: declare `assert: ^2.1.0` (dev dependency — only needed at bundle time; rolldown inlines it).
- `packages/node-tests/rolldown.config.mts`: fail hard on `UNRESOLVED_IMPORT` instead of warning, so any future phantom dependency breaks `bootstrap` loudly instead of failing masked at runtime on device. The intended addon externals are declared via `external` and are unaffected (verified both directions locally).
- `pnpm-lock.yaml`: lockfile update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MBr6N8caYidCuijvV5ak2A

---
_Generated by [Claude Code](https://claude.ai/code/session_01MBr6N8caYidCuijvV5ak2A)_