### PR TITLE
android: inject ExecOperations for Gradle 9 compatibility

### DIFF
--- a/packages/host/android/build.gradle
+++ b/packages/host/android/build.gradle
@@ -1,6 +1,8 @@
 import java.nio.file.Paths
 import groovy.json.JsonSlurper
+import javax.inject.Inject
 import org.gradle.internal.os.OperatingSystem
+import org.gradle.process.ExecOperations
 
 if (!System.getenv("REACT_NATIVE_OVERRIDE_HERMES_DIR")) {
     throw new GradleException([
@@ -161,17 +163,25 @@ dependencies {
 def commandLinePrefix = OperatingSystem.current().isWindows() ? ["cmd", "/c", "node"] : []
 def cliPath = file("../bin/react-native-node-api.mjs")
 
+// Gradle 9 removed Project.exec(), so the ExecOperations service has to be
+// injected and used explicitly instead of the bare `exec {}` closure.
+interface InjectedExecOps {
+  @Inject
+  ExecOperations getExecOps()
+}
+def injectedExecOps = project.objects.newInstance(InjectedExecOps)
+
 // Custom task to fetch jniLibs paths via CLI
 task linkNodeApiModules {
   doLast {
-    exec {
+    injectedExecOps.execOps.exec {
       commandLine commandLinePrefix + [cliPath, 'link', '--android', rootProject.rootDir.absolutePath]
       standardOutput = System.out
       errorOutput = System.err
       // Enable color output
       environment "FORCE_COLOR", "1"
     }
-    
+
     android.sourceSets.main.jniLibs.srcDirs += file("../auto-linked/android").listFiles()
   }
 }


### PR DESCRIPTION
Targets the `kh/adopt-static-h-node-api` branch (PR #372).

## Problem

RN 0.87 (adopted in #372) bumps the Gradle wrapper to 9.x, which **removed `Project.exec()`**. The `linkNodeApiModules` task in `packages/host/android/build.gradle` calls the bare `exec {}` closure inside its `doLast` action, so on Gradle 9 every Android build fails at configuration/execution with:

```
Execution failed for task ':react-native-node-api:linkNodeApiModules'.
> Could not find method exec() for arguments [...] on task ':react-native-node-api:linkNodeApiModules' of type org.gradle.api.DefaultTask.
```

On the #372 branch this reddened **every unit-test lane** (`gradle.test.ts` builds this module on ubuntu/macOS/windows) as well as the **Test app (Android)** job.

## Fix

Use the Gradle 9 supported replacement: inject the [`ExecOperations`](https://docs.gradle.org/current/javadoc/org/gradle/process/ExecOperations.html) service via an `@Inject`-annotated interface and call `injectedExecOps.execOps.exec {}` instead of the removed `Project.exec()`.

```groovy
interface InjectedExecOps {
  @Inject
  ExecOperations getExecOps()
}
def injectedExecOps = project.objects.newInstance(InjectedExecOps)
```

The command line, streams and environment passed to `exec` are unchanged.

## Test plan

- [ ] CI on the #372 branch: the three **Unit tests** lanes go green (`gradle.test.ts` builds the Android module successfully).
- [ ] **Test app (Android)** gets past the `linkNodeApiModules` failure (remaining Android e2e work is still tracked on #372).

> Native Android build isn't runnable on the CI-less Linux worker this was authored on, so the Gradle behaviour is verified by the #372 branch's CI rather than locally.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TVfanKvtyfSsoMgZv3DJtY)_