### PR TITLE
android: patch RN settings.gradle.kts /tmp projectDir for Windows

### DIFF
--- a/patches/react-native@0.87.0-nightly-20260529-88857d22f.patch
+++ b/patches/react-native@0.87.0-nightly-20260529-88857d22f.patch
@@ -2,7 +2,7 @@ diff --git a/settings.gradle.kts b/settings.gradle.kts
 index 2036e0f16450b837223aad4b73cd1d556089d16d..a769520babe1423bb08399e5a932db50de7bad51 100644
 --- a/settings.gradle.kts
 +++ b/settings.gradle.kts
-@@ -35,6 +35,11 @@ project(":packages:react-native:ReactAndroid:hermes-engine").projectDir =
+@@ -35,6 +35,16 @@ project(":packages:react-native:ReactAndroid:hermes-engine").projectDir =
  // for :packages and :packages:react-native as well as otherwise the build from
  // source will fail with a missing folder exception.
  
@@ -12,8 +12,13 @@ index 2036e0f16450b837223aad4b73cd1d556089d16d..a769520babe1423bb08399e5a932db50
 +// Patched by react-native-node-api: upstream hardcodes file("/tmp"), which does
 +// not exist on Windows (there `/tmp` resolves to a non-existent <rootDir>/tmp),
 +// so the build-from-source settings fail to configure. Use the JVM temp dir,
-+// which exists on every platform (`/tmp` on posix, %TEMP% on Windows). Remove
-+// this patch once React Native stops hardcoding "/tmp" here.
++// which exists on every platform (`/tmp` on posix, %TEMP% on Windows).
++//
++// Fixed upstream in facebook/react-native#57706, landed on main as 908872a6
++// (2026-07-28) — after the 0.87 branch cut, so 0.87-stable does NOT carry it.
++// Remove this patch once we pin a react-native that contains that commit: a
++// nightly built from main on/after 2026-07-29, or the first stable line
++// branched after it (0.88+), or a 0.87.x that cherry-picks it.
 +project(":packages").projectDir = file(System.getProperty("java.io.tmpdir", "/tmp"))
 +
 +project(":packages:react-native").projectDir = file(System.getProperty("java.io.tmpdir", "/tmp"))

--- a/patches/react-native@0.87.0-nightly-20260529-88857d22f.patch
+++ b/patches/react-native@0.87.0-nightly-20260529-88857d22f.patch
@@ -1,0 +1,19 @@
+diff --git a/settings.gradle.kts b/settings.gradle.kts
+index 2036e0f16450b837223aad4b73cd1d556089d16d..a769520babe1423bb08399e5a932db50de7bad51 100644
+--- a/settings.gradle.kts
++++ b/settings.gradle.kts
+@@ -35,6 +35,11 @@ project(":packages:react-native:ReactAndroid:hermes-engine").projectDir =
+ // for :packages and :packages:react-native as well as otherwise the build from
+ // source will fail with a missing folder exception.
+ 
+-project(":packages").projectDir = file("/tmp")
+-
+-project(":packages:react-native").projectDir = file("/tmp")
++// Patched by react-native-node-api: upstream hardcodes file("/tmp"), which does
++// not exist on Windows (there `/tmp` resolves to a non-existent <rootDir>/tmp),
++// so the build-from-source settings fail to configure. Use the JVM temp dir,
++// which exists on every platform (`/tmp` on posix, %TEMP% on Windows). Remove
++// this patch once React Native stops hardcoding "/tmp" here.
++project(":packages").projectDir = file(System.getProperty("java.io.tmpdir", "/tmp"))
++
++project(":packages:react-native").projectDir = file(System.getProperty("java.io.tmpdir", "/tmp"))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,11 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+patchedDependencies:
+  react-native@0.87.0-nightly-20260529-88857d22f:
+    hash: cb8d03652a68695fa09eeb4eb255b33445ee94077d18ebbf63255d93738d94cd
+    path: patches/react-native@0.87.0-nightly-20260529-88857d22f.patch
+
 importers:
 
   .:
@@ -49,7 +54,7 @@ importers:
         version: 0.3.21
       react-native:
         specifier: 0.87.0-nightly-20260529-88857d22f
-        version: 0.87.0-nightly-20260529-88857d22f(@babel/core@7.29.7)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.87.0-nightly-20260529-88857d22f(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3)
+        version: 0.87.0-nightly-20260529-88857d22f(patch_hash=cb8d03652a68695fa09eeb4eb255b33445ee94077d18ebbf63255d93738d94cd)(@babel/core@7.29.7)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.87.0-nightly-20260529-88857d22f(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3)
       read-pkg:
         specifier: ^9.0.1
         version: 9.0.1
@@ -103,7 +108,7 @@ importers:
         version: 0.87.0-nightly-20260529-88857d22f
       '@rnx-kit/metro-config':
         specifier: ^2.2.4
-        version: 2.2.4(@react-native-community/cli-types@20.2.0)(@react-native/metro-config@0.87.0-nightly-20260529-88857d22f(@babel/core@7.29.7))(metro@0.84.4)(react-native@0.87.0-nightly-20260529-88857d22f(@babel/core@7.29.7)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.87.0-nightly-20260529-88857d22f(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)
+        version: 2.2.4(@react-native-community/cli-types@20.2.0)(@react-native/metro-config@0.87.0-nightly-20260529-88857d22f(@babel/core@7.29.7))(metro@0.84.4)(react-native@0.87.0-nightly-20260529-88857d22f(patch_hash=cb8d03652a68695fa09eeb4eb255b33445ee94077d18ebbf63255d93738d94cd)(@babel/core@7.29.7)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.87.0-nightly-20260529-88857d22f(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)
       '@types/mocha':
         specifier: ^10.0.10
         version: 10.0.10
@@ -121,19 +126,19 @@ importers:
         version: 1.13.2
       mocha-remote-react-native:
         specifier: ^1.13.2
-        version: 1.13.2(react-native@0.87.0-nightly-20260529-88857d22f(@babel/core@7.29.7)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.87.0-nightly-20260529-88857d22f(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)
+        version: 1.13.2(react-native@0.87.0-nightly-20260529-88857d22f(patch_hash=cb8d03652a68695fa09eeb4eb255b33445ee94077d18ebbf63255d93738d94cd)(@babel/core@7.29.7)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.87.0-nightly-20260529-88857d22f(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)
       react:
         specifier: 19.2.3
         version: 19.2.3
       react-native:
         specifier: 0.87.0-nightly-20260529-88857d22f
-        version: 0.87.0-nightly-20260529-88857d22f(@babel/core@7.29.7)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.87.0-nightly-20260529-88857d22f(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3)
+        version: 0.87.0-nightly-20260529-88857d22f(patch_hash=cb8d03652a68695fa09eeb4eb255b33445ee94077d18ebbf63255d93738d94cd)(@babel/core@7.29.7)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.87.0-nightly-20260529-88857d22f(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3)
       react-native-node-api:
         specifier: workspace:*
         version: link:../../packages/host
       react-native-test-app:
         specifier: ^5.1.9
-        version: 5.4.5(@react-native-community/cli-types@20.2.0)(metro@0.84.4)(react-native@0.87.0-nightly-20260529-88857d22f(@babel/core@7.29.7)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.87.0-nightly-20260529-88857d22f(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)
+        version: 5.4.5(@react-native-community/cli-types@20.2.0)(metro@0.84.4)(react-native@0.87.0-nightly-20260529-88857d22f(patch_hash=cb8d03652a68695fa09eeb4eb255b33445ee94077d18ebbf63255d93738d94cd)(@babel/core@7.29.7)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.87.0-nightly-20260529-88857d22f(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)
       weak-node-api:
         specifier: workspace:*
         version: link:../../packages/weak-node-api
@@ -248,7 +253,7 @@ importers:
         version: 8.0.0
       react-native:
         specifier: 0.87.0-nightly-20260529-88857d22f
-        version: 0.87.0-nightly-20260529-88857d22f(@babel/core@7.29.7)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.87.0-nightly-20260529-88857d22f(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3)
+        version: 0.87.0-nightly-20260529-88857d22f(patch_hash=cb8d03652a68695fa09eeb4eb255b33445ee94077d18ebbf63255d93738d94cd)(@babel/core@7.29.7)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.87.0-nightly-20260529-88857d22f(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3)
       read-pkg:
         specifier: ^9.0.1
         version: 9.0.1
@@ -6860,12 +6865,12 @@ snapshots:
 
   '@react-native/typescript-config@0.87.0-nightly-20260529-88857d22f': {}
 
-  '@react-native/virtualized-lists@0.87.0-nightly-20260529-88857d22f(@types/react@19.2.17)(react-native@0.87.0-nightly-20260529-88857d22f(@babel/core@7.29.7)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.87.0-nightly-20260529-88857d22f(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)':
+  '@react-native/virtualized-lists@0.87.0-nightly-20260529-88857d22f(@types/react@19.2.17)(react-native@0.87.0-nightly-20260529-88857d22f(patch_hash=cb8d03652a68695fa09eeb4eb255b33445ee94077d18ebbf63255d93738d94cd)(@babel/core@7.29.7)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.87.0-nightly-20260529-88857d22f(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)':
     dependencies:
       invariant: 2.2.4
       nullthrows: 1.1.1
       react: 19.2.3
-      react-native: 0.87.0-nightly-20260529-88857d22f(@babel/core@7.29.7)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.87.0-nightly-20260529-88857d22f(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3)
+      react-native: 0.87.0-nightly-20260529-88857d22f(patch_hash=cb8d03652a68695fa09eeb4eb255b33445ee94077d18ebbf63255d93738d94cd)(@babel/core@7.29.7)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.87.0-nightly-20260529-88857d22f(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3)
     optionalDependencies:
       '@types/react': 19.2.17
 
@@ -6874,13 +6879,13 @@ snapshots:
       '@actions/core': 2.0.3
       stack-utils: 2.0.6
 
-  '@rnx-kit/metro-config@2.2.4(@react-native-community/cli-types@20.2.0)(@react-native/metro-config@0.87.0-nightly-20260529-88857d22f(@babel/core@7.29.7))(metro@0.84.4)(react-native@0.87.0-nightly-20260529-88857d22f(@babel/core@7.29.7)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.87.0-nightly-20260529-88857d22f(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)':
+  '@rnx-kit/metro-config@2.2.4(@react-native-community/cli-types@20.2.0)(@react-native/metro-config@0.87.0-nightly-20260529-88857d22f(@babel/core@7.29.7))(metro@0.84.4)(react-native@0.87.0-nightly-20260529-88857d22f(patch_hash=cb8d03652a68695fa09eeb4eb255b33445ee94077d18ebbf63255d93738d94cd)(@babel/core@7.29.7)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.87.0-nightly-20260529-88857d22f(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)':
     dependencies:
       '@rnx-kit/tools-node': 3.0.5(metro@0.84.4)
       '@rnx-kit/tools-react-native': 2.3.8(@react-native-community/cli-types@20.2.0)(metro@0.84.4)
       '@rnx-kit/tools-workspaces': 0.2.3
       react: 19.2.3
-      react-native: 0.87.0-nightly-20260529-88857d22f(@babel/core@7.29.7)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.87.0-nightly-20260529-88857d22f(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3)
+      react-native: 0.87.0-nightly-20260529-88857d22f(patch_hash=cb8d03652a68695fa09eeb4eb255b33445ee94077d18ebbf63255d93738d94cd)(@babel/core@7.29.7)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.87.0-nightly-20260529-88857d22f(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3)
     optionalDependencies:
       '@react-native/metro-config': 0.87.0-nightly-20260529-88857d22f(@babel/core@7.29.7)
     transitivePeerDependencies:
@@ -6888,9 +6893,9 @@ snapshots:
       - memfs
       - metro
 
-  '@rnx-kit/react-native-host@0.5.21(react-native@0.87.0-nightly-20260529-88857d22f(@babel/core@7.29.7)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.87.0-nightly-20260529-88857d22f(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))':
+  '@rnx-kit/react-native-host@0.5.21(react-native@0.87.0-nightly-20260529-88857d22f(patch_hash=cb8d03652a68695fa09eeb4eb255b33445ee94077d18ebbf63255d93738d94cd)(@babel/core@7.29.7)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.87.0-nightly-20260529-88857d22f(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))':
     dependencies:
-      react-native: 0.87.0-nightly-20260529-88857d22f(@babel/core@7.29.7)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.87.0-nightly-20260529-88857d22f(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3)
+      react-native: 0.87.0-nightly-20260529-88857d22f(patch_hash=cb8d03652a68695fa09eeb4eb255b33445ee94077d18ebbf63255d93738d94cd)(@babel/core@7.29.7)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.87.0-nightly-20260529-88857d22f(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3)
 
   '@rnx-kit/tools-filesystem@0.2.0': {}
 
@@ -8818,11 +8823,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  mocha-remote-react-native@1.13.2(react-native@0.87.0-nightly-20260529-88857d22f(@babel/core@7.29.7)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.87.0-nightly-20260529-88857d22f(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3):
+  mocha-remote-react-native@1.13.2(react-native@0.87.0-nightly-20260529-88857d22f(patch_hash=cb8d03652a68695fa09eeb4eb255b33445ee94077d18ebbf63255d93738d94cd)(@babel/core@7.29.7)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.87.0-nightly-20260529-88857d22f(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3):
     dependencies:
       mocha-remote-client: 1.13.2
       react: 19.2.3
-      react-native: 0.87.0-nightly-20260529-88857d22f(@babel/core@7.29.7)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.87.0-nightly-20260529-88857d22f(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3)
+      react-native: 0.87.0-nightly-20260529-88857d22f(patch_hash=cb8d03652a68695fa09eeb4eb255b33445ee94077d18ebbf63255d93738d94cd)(@babel/core@7.29.7)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.87.0-nightly-20260529-88857d22f(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -9213,24 +9218,24 @@ snapshots:
 
   react-is@18.3.1: {}
 
-  react-native-test-app@5.4.5(@react-native-community/cli-types@20.2.0)(metro@0.84.4)(react-native@0.87.0-nightly-20260529-88857d22f(@babel/core@7.29.7)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.87.0-nightly-20260529-88857d22f(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3):
+  react-native-test-app@5.4.5(@react-native-community/cli-types@20.2.0)(metro@0.84.4)(react-native@0.87.0-nightly-20260529-88857d22f(patch_hash=cb8d03652a68695fa09eeb4eb255b33445ee94077d18ebbf63255d93738d94cd)(@babel/core@7.29.7)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.87.0-nightly-20260529-88857d22f(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3):
     dependencies:
       '@isaacs/cliui': 9.0.0
-      '@rnx-kit/react-native-host': 0.5.21(react-native@0.87.0-nightly-20260529-88857d22f(@babel/core@7.29.7)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.87.0-nightly-20260529-88857d22f(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))
+      '@rnx-kit/react-native-host': 0.5.21(react-native@0.87.0-nightly-20260529-88857d22f(patch_hash=cb8d03652a68695fa09eeb4eb255b33445ee94077d18ebbf63255d93738d94cd)(@babel/core@7.29.7)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.87.0-nightly-20260529-88857d22f(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))
       '@rnx-kit/tools-react-native': 2.3.8(@react-native-community/cli-types@20.2.0)(metro@0.84.4)
       ajv: 8.20.0
       fast-xml-builder: 1.3.0
       fast-xml-parser: 5.10.1
       prompts: 2.4.2
       react: 19.2.3
-      react-native: 0.87.0-nightly-20260529-88857d22f(@babel/core@7.29.7)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.87.0-nightly-20260529-88857d22f(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3)
+      react-native: 0.87.0-nightly-20260529-88857d22f(patch_hash=cb8d03652a68695fa09eeb4eb255b33445ee94077d18ebbf63255d93738d94cd)(@babel/core@7.29.7)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.87.0-nightly-20260529-88857d22f(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3)
       semver: 7.8.5
     transitivePeerDependencies:
       - '@react-native-community/cli-types'
       - memfs
       - metro
 
-  react-native@0.87.0-nightly-20260529-88857d22f(@babel/core@7.29.7)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.87.0-nightly-20260529-88857d22f(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3):
+  react-native@0.87.0-nightly-20260529-88857d22f(patch_hash=cb8d03652a68695fa09eeb4eb255b33445ee94077d18ebbf63255d93738d94cd)(@babel/core@7.29.7)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.87.0-nightly-20260529-88857d22f(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3):
     dependencies:
       '@react-native/assets-registry': 0.87.0-nightly-20260529-88857d22f
       '@react-native/codegen': 0.87.0-nightly-20260529-88857d22f(@babel/core@7.29.7)
@@ -9238,7 +9243,7 @@ snapshots:
       '@react-native/gradle-plugin': 0.87.0-nightly-20260529-88857d22f
       '@react-native/js-polyfills': 0.87.0-nightly-20260529-88857d22f
       '@react-native/normalize-colors': 0.87.0-nightly-20260529-88857d22f
-      '@react-native/virtualized-lists': 0.87.0-nightly-20260529-88857d22f(@types/react@19.2.17)(react-native@0.87.0-nightly-20260529-88857d22f(@babel/core@7.29.7)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.87.0-nightly-20260529-88857d22f(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)
+      '@react-native/virtualized-lists': 0.87.0-nightly-20260529-88857d22f(@types/react@19.2.17)(react-native@0.87.0-nightly-20260529-88857d22f(patch_hash=cb8d03652a68695fa09eeb4eb255b33445ee94077d18ebbf63255d93738d94cd)(@babel/core@7.29.7)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.87.0-nightly-20260529-88857d22f(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)
       abort-controller: 3.0.0
       anser: 1.4.10
       ansi-regex: 5.0.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 patchedDependencies:
   react-native@0.87.0-nightly-20260529-88857d22f:
-    hash: cb8d03652a68695fa09eeb4eb255b33445ee94077d18ebbf63255d93738d94cd
+    hash: 34fb46067fb53b2193e54fc2632cbb5d5c7c01beb23096d2efa1531640cc0e08
     path: patches/react-native@0.87.0-nightly-20260529-88857d22f.patch
 
 importers:
@@ -54,7 +54,7 @@ importers:
         version: 0.3.21
       react-native:
         specifier: 0.87.0-nightly-20260529-88857d22f
-        version: 0.87.0-nightly-20260529-88857d22f(patch_hash=cb8d03652a68695fa09eeb4eb255b33445ee94077d18ebbf63255d93738d94cd)(@babel/core@7.29.7)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.87.0-nightly-20260529-88857d22f(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3)
+        version: 0.87.0-nightly-20260529-88857d22f(patch_hash=34fb46067fb53b2193e54fc2632cbb5d5c7c01beb23096d2efa1531640cc0e08)(@babel/core@7.29.7)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.87.0-nightly-20260529-88857d22f(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3)
       read-pkg:
         specifier: ^9.0.1
         version: 9.0.1
@@ -108,7 +108,7 @@ importers:
         version: 0.87.0-nightly-20260529-88857d22f
       '@rnx-kit/metro-config':
         specifier: ^2.2.4
-        version: 2.2.4(@react-native-community/cli-types@20.2.0)(@react-native/metro-config@0.87.0-nightly-20260529-88857d22f(@babel/core@7.29.7))(metro@0.84.4)(react-native@0.87.0-nightly-20260529-88857d22f(patch_hash=cb8d03652a68695fa09eeb4eb255b33445ee94077d18ebbf63255d93738d94cd)(@babel/core@7.29.7)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.87.0-nightly-20260529-88857d22f(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)
+        version: 2.2.4(@react-native-community/cli-types@20.2.0)(@react-native/metro-config@0.87.0-nightly-20260529-88857d22f(@babel/core@7.29.7))(metro@0.84.4)(react-native@0.87.0-nightly-20260529-88857d22f(patch_hash=34fb46067fb53b2193e54fc2632cbb5d5c7c01beb23096d2efa1531640cc0e08)(@babel/core@7.29.7)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.87.0-nightly-20260529-88857d22f(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)
       '@types/mocha':
         specifier: ^10.0.10
         version: 10.0.10
@@ -126,19 +126,19 @@ importers:
         version: 1.13.2
       mocha-remote-react-native:
         specifier: ^1.13.2
-        version: 1.13.2(react-native@0.87.0-nightly-20260529-88857d22f(patch_hash=cb8d03652a68695fa09eeb4eb255b33445ee94077d18ebbf63255d93738d94cd)(@babel/core@7.29.7)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.87.0-nightly-20260529-88857d22f(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)
+        version: 1.13.2(react-native@0.87.0-nightly-20260529-88857d22f(patch_hash=34fb46067fb53b2193e54fc2632cbb5d5c7c01beb23096d2efa1531640cc0e08)(@babel/core@7.29.7)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.87.0-nightly-20260529-88857d22f(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)
       react:
         specifier: 19.2.3
         version: 19.2.3
       react-native:
         specifier: 0.87.0-nightly-20260529-88857d22f
-        version: 0.87.0-nightly-20260529-88857d22f(patch_hash=cb8d03652a68695fa09eeb4eb255b33445ee94077d18ebbf63255d93738d94cd)(@babel/core@7.29.7)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.87.0-nightly-20260529-88857d22f(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3)
+        version: 0.87.0-nightly-20260529-88857d22f(patch_hash=34fb46067fb53b2193e54fc2632cbb5d5c7c01beb23096d2efa1531640cc0e08)(@babel/core@7.29.7)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.87.0-nightly-20260529-88857d22f(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3)
       react-native-node-api:
         specifier: workspace:*
         version: link:../../packages/host
       react-native-test-app:
         specifier: ^5.1.9
-        version: 5.4.5(@react-native-community/cli-types@20.2.0)(metro@0.84.4)(react-native@0.87.0-nightly-20260529-88857d22f(patch_hash=cb8d03652a68695fa09eeb4eb255b33445ee94077d18ebbf63255d93738d94cd)(@babel/core@7.29.7)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.87.0-nightly-20260529-88857d22f(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)
+        version: 5.4.5(@react-native-community/cli-types@20.2.0)(metro@0.84.4)(react-native@0.87.0-nightly-20260529-88857d22f(patch_hash=34fb46067fb53b2193e54fc2632cbb5d5c7c01beb23096d2efa1531640cc0e08)(@babel/core@7.29.7)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.87.0-nightly-20260529-88857d22f(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)
       weak-node-api:
         specifier: workspace:*
         version: link:../../packages/weak-node-api
@@ -253,7 +253,7 @@ importers:
         version: 8.0.0
       react-native:
         specifier: 0.87.0-nightly-20260529-88857d22f
-        version: 0.87.0-nightly-20260529-88857d22f(patch_hash=cb8d03652a68695fa09eeb4eb255b33445ee94077d18ebbf63255d93738d94cd)(@babel/core@7.29.7)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.87.0-nightly-20260529-88857d22f(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3)
+        version: 0.87.0-nightly-20260529-88857d22f(patch_hash=34fb46067fb53b2193e54fc2632cbb5d5c7c01beb23096d2efa1531640cc0e08)(@babel/core@7.29.7)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.87.0-nightly-20260529-88857d22f(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3)
       read-pkg:
         specifier: ^9.0.1
         version: 9.0.1
@@ -6865,12 +6865,12 @@ snapshots:
 
   '@react-native/typescript-config@0.87.0-nightly-20260529-88857d22f': {}
 
-  '@react-native/virtualized-lists@0.87.0-nightly-20260529-88857d22f(@types/react@19.2.17)(react-native@0.87.0-nightly-20260529-88857d22f(patch_hash=cb8d03652a68695fa09eeb4eb255b33445ee94077d18ebbf63255d93738d94cd)(@babel/core@7.29.7)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.87.0-nightly-20260529-88857d22f(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)':
+  '@react-native/virtualized-lists@0.87.0-nightly-20260529-88857d22f(@types/react@19.2.17)(react-native@0.87.0-nightly-20260529-88857d22f(patch_hash=34fb46067fb53b2193e54fc2632cbb5d5c7c01beb23096d2efa1531640cc0e08)(@babel/core@7.29.7)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.87.0-nightly-20260529-88857d22f(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)':
     dependencies:
       invariant: 2.2.4
       nullthrows: 1.1.1
       react: 19.2.3
-      react-native: 0.87.0-nightly-20260529-88857d22f(patch_hash=cb8d03652a68695fa09eeb4eb255b33445ee94077d18ebbf63255d93738d94cd)(@babel/core@7.29.7)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.87.0-nightly-20260529-88857d22f(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3)
+      react-native: 0.87.0-nightly-20260529-88857d22f(patch_hash=34fb46067fb53b2193e54fc2632cbb5d5c7c01beb23096d2efa1531640cc0e08)(@babel/core@7.29.7)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.87.0-nightly-20260529-88857d22f(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3)
     optionalDependencies:
       '@types/react': 19.2.17
 
@@ -6879,13 +6879,13 @@ snapshots:
       '@actions/core': 2.0.3
       stack-utils: 2.0.6
 
-  '@rnx-kit/metro-config@2.2.4(@react-native-community/cli-types@20.2.0)(@react-native/metro-config@0.87.0-nightly-20260529-88857d22f(@babel/core@7.29.7))(metro@0.84.4)(react-native@0.87.0-nightly-20260529-88857d22f(patch_hash=cb8d03652a68695fa09eeb4eb255b33445ee94077d18ebbf63255d93738d94cd)(@babel/core@7.29.7)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.87.0-nightly-20260529-88857d22f(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)':
+  '@rnx-kit/metro-config@2.2.4(@react-native-community/cli-types@20.2.0)(@react-native/metro-config@0.87.0-nightly-20260529-88857d22f(@babel/core@7.29.7))(metro@0.84.4)(react-native@0.87.0-nightly-20260529-88857d22f(patch_hash=34fb46067fb53b2193e54fc2632cbb5d5c7c01beb23096d2efa1531640cc0e08)(@babel/core@7.29.7)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.87.0-nightly-20260529-88857d22f(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)':
     dependencies:
       '@rnx-kit/tools-node': 3.0.5(metro@0.84.4)
       '@rnx-kit/tools-react-native': 2.3.8(@react-native-community/cli-types@20.2.0)(metro@0.84.4)
       '@rnx-kit/tools-workspaces': 0.2.3
       react: 19.2.3
-      react-native: 0.87.0-nightly-20260529-88857d22f(patch_hash=cb8d03652a68695fa09eeb4eb255b33445ee94077d18ebbf63255d93738d94cd)(@babel/core@7.29.7)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.87.0-nightly-20260529-88857d22f(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3)
+      react-native: 0.87.0-nightly-20260529-88857d22f(patch_hash=34fb46067fb53b2193e54fc2632cbb5d5c7c01beb23096d2efa1531640cc0e08)(@babel/core@7.29.7)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.87.0-nightly-20260529-88857d22f(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3)
     optionalDependencies:
       '@react-native/metro-config': 0.87.0-nightly-20260529-88857d22f(@babel/core@7.29.7)
     transitivePeerDependencies:
@@ -6893,9 +6893,9 @@ snapshots:
       - memfs
       - metro
 
-  '@rnx-kit/react-native-host@0.5.21(react-native@0.87.0-nightly-20260529-88857d22f(patch_hash=cb8d03652a68695fa09eeb4eb255b33445ee94077d18ebbf63255d93738d94cd)(@babel/core@7.29.7)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.87.0-nightly-20260529-88857d22f(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))':
+  '@rnx-kit/react-native-host@0.5.21(react-native@0.87.0-nightly-20260529-88857d22f(patch_hash=34fb46067fb53b2193e54fc2632cbb5d5c7c01beb23096d2efa1531640cc0e08)(@babel/core@7.29.7)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.87.0-nightly-20260529-88857d22f(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))':
     dependencies:
-      react-native: 0.87.0-nightly-20260529-88857d22f(patch_hash=cb8d03652a68695fa09eeb4eb255b33445ee94077d18ebbf63255d93738d94cd)(@babel/core@7.29.7)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.87.0-nightly-20260529-88857d22f(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3)
+      react-native: 0.87.0-nightly-20260529-88857d22f(patch_hash=34fb46067fb53b2193e54fc2632cbb5d5c7c01beb23096d2efa1531640cc0e08)(@babel/core@7.29.7)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.87.0-nightly-20260529-88857d22f(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3)
 
   '@rnx-kit/tools-filesystem@0.2.0': {}
 
@@ -8823,11 +8823,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  mocha-remote-react-native@1.13.2(react-native@0.87.0-nightly-20260529-88857d22f(patch_hash=cb8d03652a68695fa09eeb4eb255b33445ee94077d18ebbf63255d93738d94cd)(@babel/core@7.29.7)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.87.0-nightly-20260529-88857d22f(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3):
+  mocha-remote-react-native@1.13.2(react-native@0.87.0-nightly-20260529-88857d22f(patch_hash=34fb46067fb53b2193e54fc2632cbb5d5c7c01beb23096d2efa1531640cc0e08)(@babel/core@7.29.7)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.87.0-nightly-20260529-88857d22f(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3):
     dependencies:
       mocha-remote-client: 1.13.2
       react: 19.2.3
-      react-native: 0.87.0-nightly-20260529-88857d22f(patch_hash=cb8d03652a68695fa09eeb4eb255b33445ee94077d18ebbf63255d93738d94cd)(@babel/core@7.29.7)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.87.0-nightly-20260529-88857d22f(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3)
+      react-native: 0.87.0-nightly-20260529-88857d22f(patch_hash=34fb46067fb53b2193e54fc2632cbb5d5c7c01beb23096d2efa1531640cc0e08)(@babel/core@7.29.7)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.87.0-nightly-20260529-88857d22f(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -9218,24 +9218,24 @@ snapshots:
 
   react-is@18.3.1: {}
 
-  react-native-test-app@5.4.5(@react-native-community/cli-types@20.2.0)(metro@0.84.4)(react-native@0.87.0-nightly-20260529-88857d22f(patch_hash=cb8d03652a68695fa09eeb4eb255b33445ee94077d18ebbf63255d93738d94cd)(@babel/core@7.29.7)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.87.0-nightly-20260529-88857d22f(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3):
+  react-native-test-app@5.4.5(@react-native-community/cli-types@20.2.0)(metro@0.84.4)(react-native@0.87.0-nightly-20260529-88857d22f(patch_hash=34fb46067fb53b2193e54fc2632cbb5d5c7c01beb23096d2efa1531640cc0e08)(@babel/core@7.29.7)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.87.0-nightly-20260529-88857d22f(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3):
     dependencies:
       '@isaacs/cliui': 9.0.0
-      '@rnx-kit/react-native-host': 0.5.21(react-native@0.87.0-nightly-20260529-88857d22f(patch_hash=cb8d03652a68695fa09eeb4eb255b33445ee94077d18ebbf63255d93738d94cd)(@babel/core@7.29.7)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.87.0-nightly-20260529-88857d22f(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))
+      '@rnx-kit/react-native-host': 0.5.21(react-native@0.87.0-nightly-20260529-88857d22f(patch_hash=34fb46067fb53b2193e54fc2632cbb5d5c7c01beb23096d2efa1531640cc0e08)(@babel/core@7.29.7)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.87.0-nightly-20260529-88857d22f(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))
       '@rnx-kit/tools-react-native': 2.3.8(@react-native-community/cli-types@20.2.0)(metro@0.84.4)
       ajv: 8.20.0
       fast-xml-builder: 1.3.0
       fast-xml-parser: 5.10.1
       prompts: 2.4.2
       react: 19.2.3
-      react-native: 0.87.0-nightly-20260529-88857d22f(patch_hash=cb8d03652a68695fa09eeb4eb255b33445ee94077d18ebbf63255d93738d94cd)(@babel/core@7.29.7)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.87.0-nightly-20260529-88857d22f(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3)
+      react-native: 0.87.0-nightly-20260529-88857d22f(patch_hash=34fb46067fb53b2193e54fc2632cbb5d5c7c01beb23096d2efa1531640cc0e08)(@babel/core@7.29.7)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.87.0-nightly-20260529-88857d22f(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3)
       semver: 7.8.5
     transitivePeerDependencies:
       - '@react-native-community/cli-types'
       - memfs
       - metro
 
-  react-native@0.87.0-nightly-20260529-88857d22f(patch_hash=cb8d03652a68695fa09eeb4eb255b33445ee94077d18ebbf63255d93738d94cd)(@babel/core@7.29.7)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.87.0-nightly-20260529-88857d22f(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3):
+  react-native@0.87.0-nightly-20260529-88857d22f(patch_hash=34fb46067fb53b2193e54fc2632cbb5d5c7c01beb23096d2efa1531640cc0e08)(@babel/core@7.29.7)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.87.0-nightly-20260529-88857d22f(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3):
     dependencies:
       '@react-native/assets-registry': 0.87.0-nightly-20260529-88857d22f
       '@react-native/codegen': 0.87.0-nightly-20260529-88857d22f(@babel/core@7.29.7)
@@ -9243,7 +9243,7 @@ snapshots:
       '@react-native/gradle-plugin': 0.87.0-nightly-20260529-88857d22f
       '@react-native/js-polyfills': 0.87.0-nightly-20260529-88857d22f
       '@react-native/normalize-colors': 0.87.0-nightly-20260529-88857d22f
-      '@react-native/virtualized-lists': 0.87.0-nightly-20260529-88857d22f(@types/react@19.2.17)(react-native@0.87.0-nightly-20260529-88857d22f(patch_hash=cb8d03652a68695fa09eeb4eb255b33445ee94077d18ebbf63255d93738d94cd)(@babel/core@7.29.7)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.87.0-nightly-20260529-88857d22f(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)
+      '@react-native/virtualized-lists': 0.87.0-nightly-20260529-88857d22f(@types/react@19.2.17)(react-native@0.87.0-nightly-20260529-88857d22f(patch_hash=34fb46067fb53b2193e54fc2632cbb5d5c7c01beb23096d2efa1531640cc0e08)(@babel/core@7.29.7)(@react-native-community/cli@20.2.0(typescript@5.9.3))(@react-native/metro-config@0.87.0-nightly-20260529-88857d22f(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)
       abort-controller: 3.0.0
       anser: 1.4.10
       ansi-regex: 5.0.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,3 +7,5 @@ packages:
 # platform binary; allow just that one rather than disabling the safety globally.
 onlyBuiltDependencies:
   - esbuild
+patchedDependencies:
+  react-native@0.87.0-nightly-20260529-88857d22f: patches/react-native@0.87.0-nightly-20260529-88857d22f.patch


### PR DESCRIPTION
Targets the `kh/adopt-static-h-node-api` branch (PR #372). Follow-up to #386, which greened ubuntu + macOS but left **windows-latest** red on a *different* cause.

## Root cause

After #386 fixed the `Project.exec()` removal, the Windows Gradle build got further and both `gradle.test.ts` cases failed at **configuration** time:

```
Configuring project ':packages:react-native' without an existing directory is not allowed.
The configured projectDirectory '...\react-native@0.87...\node_modules\react-native\tmp' does not exist
```

This is **upstream React Native**, not our code. RN's own `settings.gradle.kts` (used for build-from-source composite builds, which this project requires) declares the intermediate container projects with a throwaway dir:

```kotlin
// Since Gradle 9.0, all the projects in the path must have an existing folder.
project(":packages").projectDir = file("/tmp")
project(":packages:react-native").projectDir = file("/tmp")
```

`/tmp` exists on the posix CI hosts, so ubuntu/macOS pass. On **Windows** `/tmp` is not absolute, so Gradle resolves it to a non-existent `<react-native>\tmp`, and **Gradle 9 hard-errors** on a missing `projectDirectory` — failing before any task runs.

## Fix

A `pnpm patch` on our pinned RN nightly, replacing `file("/tmp")` with `file(System.getProperty("java.io.tmpdir", "/tmp"))` — the JVM temp dir, which is `/tmp` on posix and `%TEMP%` on Windows and always exists.

Files:
- `patches/react-native@0.87.0-nightly-20260529-88857d22f.patch`
- `pnpm-workspace.yaml` (`patchedDependencies` entry)
- `pnpm-lock.yaml`

## Scope and tradeoffs — read before merging

**This patch is deliberately workspace-only. It is not distributed to consumers of `react-native-node-api`.**

`patchedDependencies` in `pnpm-workspace.yaml` applies to installs *in this repo* only. It is not part of the published `packages/host` tarball, and it does not apply to a user's app even if they also use pnpm. So merging this fixes **our CI**, and nothing else.

What that means for users, concretely:

- `react-native-node-api` requires building React Native **from source** on Android (we need Hermes patched with Node-API — see [docs/ANDROID.md](docs/ANDROID.md)). That is exactly the code path this RN bug breaks.
- Therefore, on **Windows hosts**, a user on an RN version that still hardcodes `/tmp` **cannot build their Android app at all** — it fails at Gradle configuration time, before any of our code runs.
- macOS and Linux hosts are unaffected (`/tmp` exists there), so this is a Windows-only user-facing gap.
- There is **no workaround we can ship**. The failure is in RN's `settings.gradle.kts`, evaluated during Gradle's settings phase of the composite build. Our Gradle plugin and our npm package are both loaded too late to intervene. The only real fixes are the upstream change, or the user applying an equivalent patch in their own app.

Why not distribute it anyway: we'd have to ask every consumer to add a patch for a *specific* RN version string, which breaks the moment they bump RN, and it would only ever have helped the subset of users who (a) are on Windows and (b) pin the same RN nightly we do. The upstream fix is already merged; carrying a distributable patch would be maintenance for a window that's closing on its own.

## Removal gate

The upstream fix is **merged**: [facebook/react-native#57706](https://github.com/facebook/react-native/pull/57706), landed on `main` as [`908872a6`](https://github.com/facebook/react-native/commit/908872a68ea3707dc9df9ba39e6669d62b3c472b) on 2026-07-28.

It landed **after the 0.87 branch cut**, so `0.87-stable` does *not* carry it — 0.87.0 final (currently at rc.4) will still be broken on Windows unless someone cherry-picks it. Revert this patch once we pin a react-native that actually contains `908872a6`:

- a nightly built from `main` on/after **2026-07-29** (our current pin is `0.87.0-nightly-20260529`, which predates it), **or**
- the first stable line branched after it (0.88+), **or**
- a 0.87.x that cherry-picks it.

Bumping the pinned nightly past 2026-07-29 would drop the patch outright — but that's a much larger change to land on top of the static_h work in #372, so it's intentionally left out of this PR.

The same condition is recorded as a comment inside the patch itself, so whoever next touches it doesn't have to find this PR.

## Test plan

- [x] CI on this branch: **Unit tests (windows-latest)** green; ubuntu/macOS green.

> The native Android build isn't runnable on the worker this was authored on, so cross-platform behaviour is verified by CI rather than locally.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TVfanKvtyfSsoMgZv3DJtY)_
