### PR TITLE
ci: drop the `--` separator when forwarding args through pnpm run

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -181,7 +181,7 @@ jobs:
       - name: Run tests (iOS)
         run: pnpm run test:ios:allTests
         # TODO: Enable release mode when it works
-        # run: pnpm run test:ios:allTests -- --mode Release
+        # run: pnpm run test:ios:allTests --mode Release
         working-directory: apps/test-app
   test-macos:
     # Disabling this on main for now, as initializing the template takes a long time and
@@ -291,7 +291,7 @@ jobs:
       - name: Build weak-node-api for all Android architectures
         run: pnpm --filter weak-node-api run prebuild:build:android
       - name: Build ferric-example for all architectures
-        run: pnpm run build -- --android
+        run: pnpm run build --android
         working-directory: packages/ferric-example
       - name: Run tests (Android)
         timeout-minutes: 75
@@ -313,7 +313,7 @@ jobs:
             adb logcat > emulator-logcat.txt 2>&1 &
             LOGCAT_PID=$!
             # Build, install and run the app
-            pnpm run test:android:allTests -- --mode Release
+            pnpm run test:android:allTests --mode Release
             # Wait a bit for the sub-process to terminate, before terminating the emulator
             sleep 5
             # Stop logcat


### PR DESCRIPTION
The Android lane has been broken since the pnpm migration (#381). Surfaced by CI on #372, which is the first run to carry the `Android 🤖` label since then.

## Root cause

npm and pnpm disagree on `run <script> -- <args>`:

| | resulting command |
|---|---|
| `npm run build -- --android` | `ferric build --android` |
| `pnpm run build -- --android` | `ferric build -- --android` |

npm swallows the separator and appends only the args; **pnpm appends the separator verbatim**. #381 rewrote these call sites mechanically (`npm run` → `pnpm run`), so the `--` started leaking into each script's own argv.

## Impact

**`packages/ferric-example` — hard failure.** The script is `ferric build`, so it ran as `ferric build -- --android`. Commander reads `--` as the options terminator, `--android` becomes a *positional* operand, and [`buildCommand`](../blob/main/packages/ferric/src/build.ts#L143) declares only options and zero arguments:

```
error: too many arguments for 'build'. Expected 0 arguments but got 1.
```

`--android` is a perfectly valid option ([`androidTarget`](../blob/main/packages/ferric/src/build.ts#L148)) — it just never gets parsed as one.

**`test:*:allTests` — subtler.** These scripts end in `-- ` (required, so `node --run` forwards to the inner script), so the extra separator survives as a literal `--` sitting ahead of `--mode Release` in the forwarded args, which then feeds `concurrently`'s `{@}` placeholder.

## Fix

Drop the separator at the three call sites in `check.yml` (two live, one commented-out iOS TODO). Verified against Node 24 / pnpm 10 that this reproduces exactly the argv these steps had under npm:

```
$ node --run inner -- --mode Release          → GOT: --mode Release     # `--` is required here
$ pnpm run outer_dash --mode Release          → GOT: --mode Release     # ✅ this PR
$ pnpm run outer_dash -- --mode Release       → GOT: -- --mode Release  # ❌ on main today
```

(where `outer_dash` is `node --run inner -- `, mirroring `test:android:allTests`)

And against the real CLI, reproducing the CI failure locally and confirming the fix parses:

```
$ ferric build -- --android --help
error: too many arguments for 'build'. Expected 0 arguments but got 2.

$ ferric build --android --help
Usage: ferric build [options]
  --android    Use all Android targets
```

## Why this wasn't caught

`test-android` is gated to `if: contains(github.event.pull_request.labels.*.name, 'Android 🤖')` — added in c77f968 because the self-hosted runner was offline and the job would otherwise queue forever on main pushes (tracked in #379). So the Android lane hasn't run since #381 landed.

## Test plan

- [ ] This PR carries the `Android 🤖` label, so **Test app (Android)** runs here: the "Build ferric-example for all architectures" step should get past the argument error, and the emulator step should then run in Release mode.

Note the iOS Release line is still commented out — that TODO is untouched beyond the separator.

---
_Generated by [Claude Code](https://claude.com/claude-code)_
