### PR TITLE
ci: stop piping the macOS xcodebuild through xcbeautify

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -222,8 +222,7 @@ jobs:
         run: npx react-native bundle --entry-file index.js --platform macos --dev false --minify false --bundle-output dist/main.macos.jsbundle --assets-dest dist/res
         working-directory: apps/macos-test-app
       - name: Build test app
-        # pipefail so an xcodebuild failure is not masked by xcbeautify's exit code
-        run: set -o pipefail && xcodebuild archive -workspace MacOSTestApp.xcworkspace -configuration Release -scheme MacOSTestApp-macOS -destination generic/platform="macOS" -archivePath ./build/macos-test-app.xcarchive | xcbeautify
+        run: xcodebuild archive -workspace MacOSTestApp.xcworkspace -configuration Release -scheme MacOSTestApp-macOS -destination generic/platform="macOS" -archivePath ./build/macos-test-app.xcarchive
         working-directory: apps/macos-test-app/macos
       - name: Run test app
         run: npx mocha-remote --exit-on-error -- macos/build/macos-test-app.xcarchive/Products/Applications/MacOSTestApp.app/Contents/MacOS/MacOSTestApp

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -185,7 +185,8 @@ jobs:
         working-directory: apps/test-app
   test-macos:
     # Disabling this on main for now, as initializing the template takes a long time and
-    # we don't have macOS-specific code yet
+    # we don't have macOS-specific code yet. Currently also blocked on react-native-macos:
+    # https://github.com/callstackincubator/react-native-node-api/issues/392
     if: contains(github.event.pull_request.labels.*.name, 'MacOS 💻')
     name: Test app (macOS)
     runs-on: macos-latest


### PR DESCRIPTION
When the macOS test app's `xcodebuild archive` fails in a *script phase*, the job log is currently undiagnosable: xcbeautify prints the failure summary (`** ARCHIVE FAILED **` plus the list of failed phases) but not the phase's own output, and its stdout is block-buffered through the pipe, so only the first handful of build lines ever reach the job log — out of order, after the summary — before the process exits.

Hit while investigating the macOS failure on #372 (tracked in #392), where both `[RN] [1] Build Hermesc` and `[CP] Copy XCFrameworks` were reported as failed with zero output explaining either; the actual cause had to be reproduced locally.

This drops the pipe entirely and takes the raw `xcodebuild` output: verbose, but complete and correctly ordered, and the step's exit code is now `xcodebuild`'s own (so the `set -o pipefail` guard is no longer needed). It was the only use of xcbeautify in the repo.

Also points the `test-macos` job's label gate at #392, which is the current reason the job doesn't run by default.

Independent of #372 — this applies to `main` as-is.

### Test plan
- [ ] `Test app (macOS)` on this PR (label-gated on `MacOS 💻`, added) — build succeeds and the log shows raw xcodebuild output

🤖 Generated with [Claude Code](https://claude.com/claude-code)