### PR TITLE
ci: publish to NPM through trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,13 @@ jobs:
     name: Release
     runs-on: macos-latest
     environment: main
+    # Publishing to NPM happens through trusted publishing, which needs an OIDC
+    # token. Declaring permissions at all narrows them to exactly what is listed,
+    # so the two the changesets action already relied on are spelled out too.
+    permissions:
+      contents: write # version commits, git tags and GitHub releases
+      pull-requests: write # the "Version Packages" pull request
+      id-token: write # NPM trusted publishing
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4


### PR DESCRIPTION
Follow-up to #396. That PR got `changeset publish` past npm's `devEngines` check, and the [next Release run](https://github.com/callstackincubator/react-native-node-api/actions/runs/31470630676/job/93712946371) then failed one step later, on authentication:

```
error an error occurred while publishing ferric-cli: ENEEDAUTH This command requires you to be logged in to https://registry.npmjs.org
error packages failed to publish:
  cmake-rn@0.7.0  ferric-cli@0.4.0  gyp-to-cmake@0.5.4  react-native-node-api@1.1.0
```

The step had no npm credentials of any kind — `NPM_TOKEN` was dropped in 3690bd1 ("Update release to use the `main` environment") and nothing has been published since 2026-01-05. The action says so itself, before running the publish script:

```
No NPM_TOKEN or OIDC available - assuming npm is already authenticated
```

`changesets/action@v1.9.0` picks one of three paths: write an `.npmrc` from `NPM_TOKEN`, use trusted publishing when `ACTIONS_ID_TOKEN_REQUEST_TOKEN` and `ACTIONS_ID_TOKEN_REQUEST_URL` are present, or assume npm is already logged in. It took the third, because the job had no OIDC token — the run's `GITHUB_TOKEN Permissions` group lists Actions, Attestations, Contents, PullRequests and friends as write, but no id-token.

## The change

Grant the job an OIDC token so the action takes its trusted publishing path. No long-lived token to store or rotate, and npm generates provenance for the published packages as a side effect.

The one subtlety: this job currently runs on the permissive default token, and **declaring `permissions:` at all narrows it to exactly what is listed**. So the two scopes the action was already relying on are spelled out alongside the new one:

- `contents: write` — version commits, git tags and GitHub releases
- `pull-requests: write` — the "Version Packages" PR
- `id-token: write` — npm trusted publishing

## Needs npm-side configuration before this works

On npmjs.com, each published package needs a trusted publisher pointing at this repository and this workflow — I can't do this part, and the publish will keep failing with `ENEEDAUTH` until it's in place:

- Repository: `callstackincubator/react-native-node-api`
- Workflow: `release.yml`
- Environment: leave blank, or set it to `main` to match the job's `environment: main` — if it's set to anything else the exchange is rejected

The 7 publishable packages: `react-native-node-api`, `cmake-rn`, `cmake-file-api`, `ferric-cli`, `gyp-to-cmake`, `weak-node-api`, `@react-native-node-api/cli-utils`. Only four are behind right now, but the other three will need it for their next release.

## Notes

- Runner-side requirements are already met: npm 11.17 on the runner (trusted publishing needs ≥ 11.5.1), and pnpm 10.33.0, which delegates the upload to `npm publish`. Worth knowing for later: [pnpm#11513](https://github.com/pnpm/pnpm/issues/11513) reports OIDC publishing regressing in pnpm 11, so bumping the pinned pnpm major deserves a check against this workflow.
- `npm_config_force` from #396 stays for now — it is still needed for the `npm info` calls that `changeset publish` makes. #397 tracks removing it along with the Changesets v3 upgrade.

---
_Generated by [Claude Code](https://claude.ai/code/session_01P2UZcjV4P98WFjzfRfLQvx)_