### PR TITLE
ci: set Node.js up before pnpm and move to pnpm/action-setup v6

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -25,18 +25,18 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-# Two actions below are deliberately held back from their newest release, both
-# because of the Node.js 20 deprecation:
+# Every job sets Node.js up before pnpm, which is the opposite of what pnpm's
+# own docs suggest. pnpm/action-setup v6 bootstraps pnpm by shelling out to
+# `npm ci`, and it finds npm on PATH — on our self-hosted Linux runner the only
+# npm there is the broken copy in the runner's own Node.js 24 externals, so the
+# setup step dies with "Cannot find module '../lib/cli.js'". Running setup-node
+# first puts a working npm ahead of it. The usual ordering exists so that
+# setup-node's `cache: pnpm` can shell out to `pnpm store path`; pnpm's own
+# `cache: true` caches the same store without needing pnpm to already exist.
 #
-# - pnpm/action-setup is pinned to v5, not v6. v6 rewrote the self-installer to
-#   shell out to `npm ci`, and our self-hosted Linux runner has no npm on PATH
-#   beyond the runner's own Node.js 24 externals — where it is broken. v5 is a
-#   Node.js 24 action too, and still bootstraps from a bundled pnpm, so it
-#   clears the deprecation without the new npm dependency. Move to v6 once that
-#   runner has a working npm.
-# - hendrikmuhs/ccache-action is pinned to an exact patch because its floating
-#   v1 / v1.2 tags still point at a Node.js 20 build. Float again once upstream
-#   moves them to >= v1.2.22.
+# hendrikmuhs/ccache-action is pinned to an exact patch, not a floating major:
+# its v1 / v1.2 tags still point at a Node.js 20 build, which the runners now
+# warn about. Float again once upstream moves them to >= v1.2.22.
 
 jobs:
   lint:
@@ -44,11 +44,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: pnpm/action-setup@v5
       - uses: actions/setup-node@v7
         with:
           node-version: lts/krypton
-          cache: pnpm
+      - uses: pnpm/action-setup@v6
+        with:
+          cache: true
       - name: Setup cpp tools
         uses: aminya/setup-cpp@v1
         with:
@@ -93,11 +94,12 @@ jobs:
     name: Unit tests (${{ matrix.runner }})
     steps:
       - uses: actions/checkout@v7
-      - uses: pnpm/action-setup@v5
       - uses: actions/setup-node@v7
         with:
           node-version: lts/krypton
-          cache: pnpm
+      - uses: pnpm/action-setup@v6
+        with:
+          cache: true
       - name: Setup cpp tools
         uses: aminya/setup-cpp@v1
         with:
@@ -132,11 +134,12 @@ jobs:
     name: Weak Node-API tests (${{ matrix.runner }})
     steps:
       - uses: actions/checkout@v7
-      - uses: pnpm/action-setup@v5
       - uses: actions/setup-node@v7
         with:
           node-version: lts/krypton
-          cache: pnpm
+      - uses: pnpm/action-setup@v6
+        with:
+          cache: true
       - name: Setup cpp tools
         uses: aminya/setup-cpp@v1
         with:
@@ -161,11 +164,12 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: pnpm/action-setup@v5
       - uses: actions/setup-node@v7
         with:
           node-version: lts/krypton
-          cache: pnpm
+      - uses: pnpm/action-setup@v6
+        with:
+          cache: true
       - name: Setup cpp tools
         uses: aminya/setup-cpp@v1
         with:
@@ -205,11 +209,12 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: pnpm/action-setup@v5
       - uses: actions/setup-node@v7
         with:
           node-version: lts/krypton
-          cache: pnpm
+      - uses: pnpm/action-setup@v6
+        with:
+          cache: true
       - name: Setup cpp tools
         uses: aminya/setup-cpp@v1
         with:
@@ -253,11 +258,12 @@ jobs:
     runs-on: ubuntu-self-hosted
     steps:
       - uses: actions/checkout@v7
-      - uses: pnpm/action-setup@v5
       - uses: actions/setup-node@v7
         with:
           node-version: lts/krypton
-          cache: pnpm
+      - uses: pnpm/action-setup@v6
+        with:
+          cache: true
       - name: Setup cpp tools
         uses: aminya/setup-cpp@v1
         with:
@@ -343,11 +349,12 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: pnpm/action-setup@v5
       - uses: actions/setup-node@v7
         with:
           node-version: lts/krypton
-          cache: pnpm
+      - uses: pnpm/action-setup@v6
+        with:
+          cache: true
       - name: Setup cpp tools
         uses: aminya/setup-cpp@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,8 +20,8 @@ on:
 # refreshing the "Version Packages" pull request until someone approves. The
 # two jobs that must not overlap carry their own groups instead.
 
-# pnpm/action-setup is pinned to v5 and hendrikmuhs/ccache-action to an exact
-# patch, both for Node.js 20 deprecation reasons. See the note in check.yml.
+# Node.js is set up before pnpm, and hendrikmuhs/ccache-action is pinned to an
+# exact patch rather than a floating major. See the note in check.yml for why.
 
 jobs:
   # changesets/action's sub-actions split the "what should happen?" decision out
@@ -39,11 +39,12 @@ jobs:
       mode: ${{ steps.select.outputs.mode }}
     steps:
       - uses: actions/checkout@v7
-      - uses: pnpm/action-setup@v5
       - uses: actions/setup-node@v7
         with:
           node-version: lts/krypton
-          cache: pnpm
+      - uses: pnpm/action-setup@v6
+        with:
+          cache: true
       # select-mode runs the locally installed @changesets/cli, so the workspace
       # has to be installed before it.
       - run: pnpm install
@@ -71,11 +72,12 @@ jobs:
       pull-requests: write # the "Version Packages" pull request
     steps:
       - uses: actions/checkout@v7
-      - uses: pnpm/action-setup@v5
       - uses: actions/setup-node@v7
         with:
           node-version: lts/krypton
-          cache: pnpm
+      - uses: pnpm/action-setup@v6
+        with:
+          cache: true
       - run: pnpm install
 
       - name: Create Release Pull Request
@@ -98,11 +100,12 @@ jobs:
       id-token: write # NPM trusted publishing
     steps:
       - uses: actions/checkout@v7
-      - uses: pnpm/action-setup@v5
       - uses: actions/setup-node@v7
         with:
           node-version: lts/krypton
-          cache: pnpm
+      - uses: pnpm/action-setup@v6
+        with:
+          cache: true
       - name: Setup cpp tools
         uses: aminya/setup-cpp@v1
         with:


### PR DESCRIPTION
Follow-up to #405, which held `pnpm/action-setup` at v5 rather than moving it to v6.

## Why v5 was held back

v6 rewrote the self-installer to bootstrap pnpm by shelling out to `npm ci`. It resolves `npm` through `PATH`, and only **appends** the runner's own Node.js directory to it. On the self-hosted Linux runner the only `npm` reachable that way is the copy in the runner's Node.js 24 externals, and that copy is broken — the shim is present but npm's `lib/` is not:

```
Error: Cannot find module '../lib/cli.js'
Require stack:
- /home/.../actions-runner/externals.2.336.0/node24/bin/npm
```

So `Test app (Android)` died at the setup step.

## What this changes

Because v6 *appends* rather than prepends, running `actions/setup-node` first — which prepends its own Node.js installation — puts a working `npm` ahead of the broken one. So every job now sets Node.js up before pnpm.

That ordering was previously impossible: `actions/setup-node`'s `cache: pnpm` shells out to `pnpm store path --silent`, so pnpm had to already exist. v6 caches the pnpm store itself, keyed on the lockfile, so the input moves from one action to the other and the constraint goes away:

```yaml
- uses: actions/setup-node@v7
  with:
    node-version: lts/krypton   # no `cache: pnpm`
- uses: pnpm/action-setup@v6
  with:
    cache: true
```

Applied to all ten job definitions across both workflows. The rationale lives in one note at the top of `check.yml` rather than repeated per step.

## Risk

The PATH-precedence reasoning is sound but only a real run on the self-hosted runner proves it, so treat this as a hypothesis under test. If `Test app (Android)` fails at the setup step again, reverting to the v5 arrangement from #405 is the known-good fallback.

The first run on each job will have a cold pnpm store cache, since the cache key namespace moves from `actions/setup-node` to `pnpm/action-setup`.

`hendrikmuhs/ccache-action` stays pinned to an exact patch — unrelated to this change, and its floating tags still point at a Node.js 20 build.

---
_Generated by [Claude Code](https://claude.ai/code/session_01W14eEfXdK5DYzv43MazryE)_