### PR TITLE
ci: bring host-cpp-tests in line with the rest of the workflow

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -171,18 +171,19 @@ jobs:
     runs-on: ${{ matrix.runner }}
     name: Host C++ tests (${{ matrix.runner }})
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: lts/krypton
-          cache: pnpm
+      - uses: pnpm/action-setup@v6
+        with:
+          cache: true
       - name: Setup cpp tools
         uses: aminya/setup-cpp@v1
         with:
           clang-format: true
       - name: ccache
-        uses: hendrikmuhs/ccache-action@v1.2
+        uses: hendrikmuhs/ccache-action@v1.2.23
         with:
           key: ${{ github.job }}-${{ runner.os }}
       - run: pnpm install


### PR DESCRIPTION
Follow-up to #405 and #407, which swept the Node.js 20 deprecation out of the workflows on `main`.

`host-cpp-tests` was added on `next` (#398), so it was never in the diff of either sweep. It is the one job in `check.yml` still on `actions/checkout@v4`, `pnpm/action-setup@v4` and `actions/setup-node@v6` — and therefore the only remaining source of the runner's "targets Node.js 20 but are being forced to run on Node.js 24" warning anywhere in the repo.

## Changes

Gives `host-cpp-tests` the same arrangement its seven siblings already have on `next`:

```yaml
- uses: actions/checkout@v7
- uses: actions/setup-node@v7
  with:
    node-version: lts/krypton
- uses: pnpm/action-setup@v6
  with:
    cache: true
```

plus `hendrikmuhs/ccache-action` pinned to `v1.2.23`, since its floating `v1` / `v1.2` tags still resolve to a Node.js 20 build.

Node.js is set up before pnpm rather than after — the reasoning is in the note at the top of `check.yml`. Short version: v6 bootstraps pnpm via `npm ci` and resolves `npm` through `PATH`, so it needs a working npm ahead of the broken copy in the self-hosted runner's Node.js 24 externals. That ordering used to be impossible because `setup-node`'s `cache: pnpm` shells out to `pnpm store path`; v6 caches the store itself, so the constraint is gone.

After this, all eight jobs in `check.yml` share the same first three steps.

## Notes

`host-cpp-tests` is gated on the `host` label for pull requests, so that label is applied here to actually exercise the change on all three runners.