### PR TITLE
ci: verify the ferric Apple binaries depend on weak-node-api

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -449,14 +449,19 @@ jobs:
           # Verify every binary depends on the weak-node-api framework.
           # otool -L prints one header line per file, or one per architecture
           # when the file is fat, so the number of headers is exactly the number
-          # of "@rpath/weak-node-api.framework/weak-node-api" lines we expect.
-          # Deriving it beats hard-coding a count, which silently rots whenever
-          # a triplet is added or dropped.
+          # of weak-node-api dependencies we expect. Deriving it beats
+          # hard-coding a count, which silently rots whenever a triplet is added
+          # or dropped.
+          # macOS frameworks use the versioned bundle layout, so their install
+          # name is .../weak-node-api.framework/Versions/<version>/weak-node-api
+          # where the embedded platforms get the flat
+          # .../weak-node-api.framework/weak-node-api — hence the optional
+          # "Versions/<version>/" in the pattern.
           SLICE_COUNT=$(grep -c "^ferric_example\.apple\.node/.*:$" otool-output.txt || true)
-          WEAK_NODE_API_COUNT=$(grep -c "@rpath/weak-node-api\.framework/weak-node-api" otool-output.txt || true)
+          WEAK_NODE_API_COUNT=$(grep -cE "@rpath/weak-node-api\.framework/(Versions/[^/]+/)?weak-node-api" otool-output.txt || true)
           echo "Found $WEAK_NODE_API_COUNT weak-node-api dependencies across $SLICE_COUNT binaries"
           if [ "$SLICE_COUNT" -eq 0 ] || [ "$WEAK_NODE_API_COUNT" -ne "$SLICE_COUNT" ]; then
-            echo "Expected $SLICE_COUNT occurrences of @rpath/weak-node-api.framework/weak-node-api (one per binary), found $WEAK_NODE_API_COUNT"
+            echo "Expected $SLICE_COUNT dependencies on the weak-node-api framework (one per binary), found $WEAK_NODE_API_COUNT"
             cat otool-output.txt
             exit 1
           fi

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -418,17 +418,24 @@ jobs:
       - run: pnpm exec ferric --apple
         working-directory: packages/ferric-example
       - name: Inspect the structure of the prebuilt binary
-        run: lipo -info ferric_example.apple.node/*/libferric_example.framework/libferric_example > lipo-info.txt
+        run: |
+          lipo -info ferric_example.apple.node/*/libferric_example.framework/libferric_example > lipo-output.txt
+          otool -L ferric_example.apple.node/*/libferric_example.framework/libferric_example > otool-output.txt
         working-directory: packages/ferric-example
-      - name: Upload lipo info
+      - name: Upload lipo output
         uses: actions/upload-artifact@v7
         with:
-          name: lipo-info
-          path: packages/ferric-example/lipo-info.txt
+          name: lipo-output
+          path: packages/ferric-example/lipo-output.txt
+      - name: Upload otool output
+        uses: actions/upload-artifact@v7
+        with:
+          name: otool-output
+          path: packages/ferric-example/otool-output.txt
       - name: Verify Apple triplet builds
         run: |
           # Create expected fixture content
-          cat > expected-lipo-info.txt << 'EOF'
+          cat > expected-lipo-output.txt << 'EOF'
           Architectures in the fat file: ferric_example.apple.node/ios-arm64_x86_64-simulator/libferric_example.framework/libferric_example are: x86_64 arm64 
           Architectures in the fat file: ferric_example.apple.node/macos-arm64_x86_64/libferric_example.framework/libferric_example are: x86_64 arm64 
           Architectures in the fat file: ferric_example.apple.node/tvos-arm64_x86_64-simulator/libferric_example.framework/libferric_example are: x86_64 arm64 
@@ -438,5 +445,19 @@ jobs:
           Non-fat file: ferric_example.apple.node/xros-arm64/libferric_example.framework/libferric_example is architecture: arm64
           EOF
           # Compare with expected fixture (will fail if files differ)
-          diff expected-lipo-info.txt lipo-info.txt
+          diff expected-lipo-output.txt lipo-output.txt
+          # Verify every binary depends on the weak-node-api framework.
+          # otool -L prints one header line per file, or one per architecture
+          # when the file is fat, so the number of headers is exactly the number
+          # of "@rpath/weak-node-api.framework/weak-node-api" lines we expect.
+          # Deriving it beats hard-coding a count, which silently rots whenever
+          # a triplet is added or dropped.
+          SLICE_COUNT=$(grep -c "^ferric_example\.apple\.node/.*:$" otool-output.txt || true)
+          WEAK_NODE_API_COUNT=$(grep -c "@rpath/weak-node-api\.framework/weak-node-api" otool-output.txt || true)
+          echo "Found $WEAK_NODE_API_COUNT weak-node-api dependencies across $SLICE_COUNT binaries"
+          if [ "$SLICE_COUNT" -eq 0 ] || [ "$WEAK_NODE_API_COUNT" -ne "$SLICE_COUNT" ]; then
+            echo "Expected $SLICE_COUNT occurrences of @rpath/weak-node-api.framework/weak-node-api (one per binary), found $WEAK_NODE_API_COUNT"
+            cat otool-output.txt
+            exit 1
+          fi
         working-directory: packages/ferric-example


### PR DESCRIPTION
Redo of #336 (and the #335 it was stacked on), rebased onto `next` and with the check actually verified against a real CI run instead of guessed.

To help increase confidence and avoid future regressions, the "Test ferric Apple triplets" job now checks the `otool` output too, so it doesn't only assert *which* architectures were produced but also that every produced binary actually links `weak-node-api.framework`.

## Changes

- Run `otool -L` alongside `lipo -info` on the built framework binaries, and upload both as artifacts.
- Assert that every binary slice lists a dependency on `weak-node-api.framework`.
- Rename `lipo-info.txt` to `lipo-output.txt`, for symmetry with the new `otool-output.txt`.

## Why not a hard-coded count

#335 hard-coded `-ne 4`; #336 changed it to `7`, reasoning "3 fat binaries + 4 thin binaries". Both are wrong, and in two independent ways that a hard-coded number can't express:

1. `otool -L` prints one header — and therefore one dependency list — **per architecture slice** for a fat file, not one per file. With 3 fat (2 archs each) + 4 thin binaries there are **10** dependency lists, not 7.
2. Not every slice spells the dependency the same way (see below).

So the expected count is now derived from the `otool` output itself by counting its header lines. It can't drift out of sync with the `lipo` fixture above it, and it doesn't need updating when a triplet is added or dropped. The step echoes what it found, so the numbers are visible in the job log on success as well as failure.

## What the verification run turned up

The first run of this check on CI reported:

```
Found 8 weak-node-api dependencies across 10 binaries
```

The two misses were the **macOS** slices. macOS frameworks use the versioned bundle layout, so the install name there is

```
@rpath/weak-node-api.framework/Versions/0.1.1/weak-node-api
```

where iOS, tvOS and visionOS get the flat

```
@rpath/weak-node-api.framework/weak-node-api
```

Both are a genuine dependency on the framework, so the pattern now accepts an optional `Versions/{version}/` path component. This is exactly the sort of detail a hard-coded `4` or `7` would have papered over — with `7` the check would have passed while two slices went unmatched, and the number would have looked "verified".

After the fix, CI reports:

```
Found 10 weak-node-api dependencies across 10 binaries
```