### PR TITLE
fix(host): make `vendor-hermes --silent` actually silent

### DIFF
--- a/.changeset/silent-vendor-hermes.md
+++ b/.changeset/silent-vendor-hermes.md
@@ -1,0 +1,9 @@
+---
+"react-native-node-api": patch
+---
+
+Make `vendor-hermes --silent` actually silent. The spinners were passed
+`isEnabled: false`, which stops the animation but still writes the spinner text
+and its final symbol to stderr. They now use `isSilent`, which suppresses the
+output entirely, leaving the vendored Hermes path on stdout as the command's
+only output.

--- a/packages/host/src/node/cli/hermes.ts
+++ b/packages/host/src/node/cli/hermes.ts
@@ -90,7 +90,7 @@ export const command = new Command("vendor-hermes")
             successText: "Removed existing Hermes clone",
             failText: (error) =>
               `Failed to remove existing Hermes clone: ${error.message}`,
-            isEnabled: !silent,
+            isSilent: silent,
           },
         );
       }
@@ -123,7 +123,7 @@ export const command = new Command("vendor-hermes")
               text: `Cloning Hermes into ${prettyPath(hermesPath)}`,
               successText: "Cloned Hermes",
               failText: (err) => `Failed to clone Hermes: ${err.message}`,
-              isEnabled: !silent,
+              isSilent: silent,
             },
           );
         } catch (error) {


### PR DESCRIPTION
`vendor-hermes --silent` passed `isEnabled: !silent` to its spinners. In ora, a
disabled spinner is not a silent one — `start()` still writes `- <text>` and
`stopAndPersist()` still writes the success/fail symbol, both to stderr; only
the animation is skipped. `isSilent: true` returns early from both.

Verified against the installed ora 8.2.0:

```
--- isEnabled: false (before), stdout+stderr ---
- Working
√ Done
/path/to/hermes
--- isSilent: true (after), stdout+stderr ---
/path/to/hermes
```

Every caller captures stdout only — `$(pnpm exec react-native-node-api
vendor-hermes --silent)` in `check.yml` and in the Gradle error message from
`packages/host/android/build.gradle`, and the backticks in
`packages/host/scripts/patch-hermes.rb` — so this was stray output rather than a
corrupted path. The flag now does what it documents.

Picked out of the long-stale #188, which proposed the same change against code
that has since been rewritten.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HX4imsygeawVtsmoP1sj3F)_