### PR TITLE
cmake-rn: make CODE_SIGNING_ALLOWED configurable for Apple builds

### DIFF
--- a/.changeset/silly-cobras-invite.md
+++ b/.changeset/silly-cobras-invite.md
@@ -1,0 +1,5 @@
+---
+"cmake-rn": minor
+---
+
+Add a `--code-signing-allowed` flag to `cmake-rn`. `CODE_SIGNING_ALLOWED=NO` remains the default (needed for the free-standing dynamic libraries we produce), but a consumer who needs signed binaries in the XCFramework can now pass `--code-signing-allowed` to opt in.

--- a/packages/cmake-rn/src/platforms/apple.ts
+++ b/packages/cmake-rn/src/platforms/apple.ts
@@ -161,9 +161,15 @@ const appleBundleIdentifierOption = new Option(
   "Unique CFBundleIdentifier used for Apple framework artifacts",
 ).default(undefined, "com.callstackincubator.node-api.{libraryName}");
 
+const codeSigningAllowedOption = new Option(
+  "--code-signing-allowed",
+  "Allow code signing when building free dynamic libraries (passed as CODE_SIGNING_ALLOWED to xcodebuild)",
+).default(false);
+
 type AppleOpts = {
   xcframeworkExtension: boolean;
   appleBundleIdentifier?: string;
+  codeSigningAllowed: boolean;
 };
 
 function getBuildPath(baseBuildPath: string, triplet: Triplet) {
@@ -259,7 +265,8 @@ export const platform: Platform<Triplet[], AppleOpts> = {
   amendCommand(command) {
     return command
       .addOption(xcframeworkExtensionOption)
-      .addOption(appleBundleIdentifierOption);
+      .addOption(appleBundleIdentifierOption)
+      .addOption(codeSigningAllowedOption);
   },
   assertValidTriplets(triplets) {
     for (const suffix of SIMULATOR_TRIPLET_SUFFIXES) {
@@ -366,7 +373,7 @@ export const platform: Platform<Triplet[], AppleOpts> = {
   },
   async build(
     { spawn, triplet },
-    { build, target, configuration, appleBundleIdentifier },
+    { build, target, configuration, appleBundleIdentifier, codeSigningAllowed },
   ) {
     // We expect the final application to sign these binaries
     if (target.length > 1) {
@@ -440,9 +447,10 @@ export const platform: Platform<Triplet[], AppleOpts> = {
         ...(target.length > 0 ? ["--target", ...target] : []),
         "--",
 
-        // Skip code-signing (needed when building free dynamic libraries)
-        // TODO: Make this configurable
-        "CODE_SIGNING_ALLOWED=NO",
+        // Skip code-signing by default (needed when building free dynamic
+        // libraries), but let a consumer opt into signed binaries via
+        // --code-signing-allowed.
+        `CODE_SIGNING_ALLOWED=${codeSigningAllowed ? "YES" : "NO"}`,
       ]);
       // Create a framework
       const { artifacts } = sharedLibrary;


### PR DESCRIPTION
## Summary

This addresses the Apple half of #418 (the Android `ANDROID_STL` half is a separate PR).

`packages/cmake-rn/src/platforms/apple.ts` passed `CODE_SIGNING_ALLOWED=NO` to `xcodebuild` unconditionally when building free dynamic libraries. That's the right default (we produce free-standing dynamic libraries), but a consumer who needs signed binaries in the XCFramework — enterprise distribution, or a target whose downstream tooling verifies signatures — had no way to override it.

## Changes

- Added a `--code-signing-allowed` CLI option (and corresponding `AppleOpts.codeSigningAllowed` programmatic option), following the same `Option` + `amendCommand` pattern already used for `--xcframework-extension` and `--apple-bundle-identifier`.
- Defaults to `false` (unchanged behavior: `CODE_SIGNING_ALLOWED=NO`); passing `--code-signing-allowed` now produces `CODE_SIGNING_ALLOWED=YES`, still appended after `--` to the `cmake --build` invocation that drives `xcodebuild`, matching the existing mechanism.
- Added a `minor` changeset for `cmake-rn` (backward compatible new capability; repo is in changesets pre-release mode targeting `next`/`rc`).

## Validation

- `pnpm install && pnpm run build`
- `pnpm --filter cmake-rn run test`
- `pnpm exec eslint packages/cmake-rn/src/platforms/apple.ts`
- `pnpm exec prettier --check packages/cmake-rn/src/platforms/apple.ts .changeset/*.md`

No existing test in `cmake-rn`'s suite exercises `platforms/apple.ts`'s `build()` args array (it isn't set up for that kind of mocking), so no test was extended — happy to add one if there's a preferred harness for it.

---
🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01DaK9eAAF5G8wj6UT8VekAm

---
_Generated by [Claude Code](https://claude.ai/code/session_01DaK9eAAF5G8wj6UT8VekAm)_