### PR TITLE
fix(host): compile out log_debug in release (NDEBUG) builds

### DIFF
--- a/.changeset/release-debug-logging.md
+++ b/.changeset/release-debug-logging.md
@@ -1,0 +1,10 @@
+---
+"react-native-node-api": patch
+---
+
+Stop emitting `log_debug`'s per-addon diagnostic chatter (library
+found/loaded, symbol resolution, ...) in release builds. It is now compiled
+out in `NDEBUG` builds (CMake's `Release`/`MinSizeRel`/`RelWithDebInfo`
+configurations, and Xcode's default `Release` configuration), mirroring React
+Native's own dev/release logging split. `log_warning` and `log_error` are
+unaffected and keep firing in every build type.

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -4,6 +4,33 @@ Guidance specific to Claude Code sessions that open pull requests against this
 repository (including automated/scheduled sessions). See the root `CLAUDE.md`
 and `AGENTS.md` for everything else.
 
+## Keep inline comments very brief — put the color in the PR description
+
+Default to **no comment at all**. Write one only when it carries knowledge a
+reader cannot get from the code itself plus a `git blame` pointing at the PR
+that introduced it. When you do write one, keep it to a line or two.
+
+Rationale, rejected alternatives, benchmark numbers, "we tried X and it
+didn't work", links to upstream issues, and anything that reads as a history
+lesson belong in the **PR description** (and, where user-facing, the
+changeset) — not in the source. Those places are where a reader who has
+already found the line via `git blame` will end up anyway, and they don't
+have to be maintained as the code around them changes.
+
+Concretely, do not write comments that:
+
+- restate what the next line already says;
+- explain why an alternative implementation was _not_ chosen;
+- narrate the change (`// now compiled out in release builds`) — that is a
+  commit message, and it goes stale the moment the code moves;
+- document a well-known toolchain fact (e.g. what `NDEBUG` means) that a
+  reader can look up.
+
+Comments that _do_ earn their place: a non-obvious constraint the compiler or
+platform imposes, a workaround with the exact condition that makes it
+removable (see the upstream-fix guidance in `AGENTS.md`), or a subtle
+invariant a future edit could silently break.
+
 ## Attach CI labels when you open a PR
 
 `.github/workflows/check.yml`'s `pull_request` trigger only fires on

--- a/packages/host/cpp/Logger.cpp
+++ b/packages/host/cpp/Logger.cpp
@@ -63,13 +63,18 @@ void log_message_internal(LogLevel level, const char *format, va_list args) {
 
 namespace callstack::react_native_node_api {
 
+// See the comment on the declaration in Logger.hpp: in release (NDEBUG)
+// builds log_debug is an inline no-op defined in the header, so this
+// definition only exists (and only needs to exist) outside of NDEBUG.
+#ifndef NDEBUG
 void log_debug(const char *format, ...) {
-  // TODO: Disable logging in release builds
   va_list args;
   va_start(args, format);
   log_message_internal(LogLevel::Debug, format, args);
   va_end(args);
 }
+#endif
+
 void log_warning(const char *format, ...) {
   va_list args;
   va_start(args, format);

--- a/packages/host/cpp/Logger.cpp
+++ b/packages/host/cpp/Logger.cpp
@@ -63,9 +63,6 @@ void log_message_internal(LogLevel level, const char *format, va_list args) {
 
 namespace callstack::react_native_node_api {
 
-// See the comment on the declaration in Logger.hpp: in release (NDEBUG)
-// builds log_debug is an inline no-op defined in the header, so this
-// definition only exists (and only needs to exist) outside of NDEBUG.
 #ifndef NDEBUG
 void log_debug(const char *format, ...) {
   va_list args;

--- a/packages/host/cpp/Logger.hpp
+++ b/packages/host/cpp/Logger.hpp
@@ -4,31 +4,14 @@
 
 namespace callstack::react_native_node_api {
 
-// log_debug is verbose, per-addon diagnostic chatter (library found/loaded,
-// symbol resolution, ...) emitted on every addon load. It is compiled out
-// entirely in release builds: NDEBUG is what CMake's Release/MinSizeRel/
-// RelWithDebInfo configurations define (and what Xcode's Release
-// configuration defines by default), mirroring the dev/release split React
-// Native itself draws with `__DEV__`. Making the release build's log_debug an
-// inline no-op - rather than compiling Logger.cpp's definition and letting it
-// run - drops both the log line and its argument-formatting cost from the
-// startup path, and lets the optimizer elide side-effect-free call sites
-// entirely.
-//
-// This is compile-time only: there is currently no runtime override to
-// re-enable it in a shipped release build to chase a release-only bug (there
-// is no existing mechanism in this codebase - env var, JS-settable flag, etc.
-// - to hook one into without adding new plumbing of its own). Build a
-// Debug or RelWithDebInfo artifact to get this output back; revisit with a
-// runtime toggle if that turns out to be too painful in practice.
+// Inline (rather than a no-op in Logger.cpp) to let the optimizer drop the
+// argument evaluation at every call site.
 #ifdef NDEBUG
 inline void log_debug(const char *, ...) {}
 #else
 void log_debug(const char *format, ...);
 #endif
 
-// log_warning/log_error keep firing unconditionally in every build type,
-// including release (NDEBUG) ones.
 void log_warning(const char *format, ...);
 void log_error(const char *format, ...);
 

--- a/packages/host/cpp/Logger.hpp
+++ b/packages/host/cpp/Logger.hpp
@@ -3,7 +3,33 @@
 #include <string>
 
 namespace callstack::react_native_node_api {
+
+// log_debug is verbose, per-addon diagnostic chatter (library found/loaded,
+// symbol resolution, ...) emitted on every addon load. It is compiled out
+// entirely in release builds: NDEBUG is what CMake's Release/MinSizeRel/
+// RelWithDebInfo configurations define (and what Xcode's Release
+// configuration defines by default), mirroring the dev/release split React
+// Native itself draws with `__DEV__`. Making the release build's log_debug an
+// inline no-op - rather than compiling Logger.cpp's definition and letting it
+// run - drops both the log line and its argument-formatting cost from the
+// startup path, and lets the optimizer elide side-effect-free call sites
+// entirely.
+//
+// This is compile-time only: there is currently no runtime override to
+// re-enable it in a shipped release build to chase a release-only bug (there
+// is no existing mechanism in this codebase - env var, JS-settable flag, etc.
+// - to hook one into without adding new plumbing of its own). Build a
+// Debug or RelWithDebInfo artifact to get this output back; revisit with a
+// runtime toggle if that turns out to be too painful in practice.
+#ifdef NDEBUG
+inline void log_debug(const char *, ...) {}
+#else
 void log_debug(const char *format, ...);
+#endif
+
+// log_warning/log_error keep firing unconditionally in every build type,
+// including release (NDEBUG) ones.
 void log_warning(const char *format, ...);
 void log_error(const char *format, ...);
+
 } // namespace callstack::react_native_node_api


### PR DESCRIPTION
Closes #420.

## Problem

`log_debug` in `packages/host/cpp/Logger.cpp` formatted and emitted
unconditionally, with no build-configuration guard anywhere in the file. The
host calls it on every addon load (`CxxNodeApiHostModule.cpp`'s "Found
napi_register_module_v1" / "Failed to find..." / resolution chatter, plus
`AddonLoaders.hpp`'s load-failure logging) — so a shipped release app got
per-addon logcat/`os_log` output nobody asked for, plus string-formatting
cost on a startup path. `log_warning`/`log_error` were not affected by this
issue and already fire unconditionally.

## Fix

`log_debug` is now an inline no-op declared directly in `Logger.hpp` when
`NDEBUG` is defined; `Logger.cpp`'s real definition is compiled only when
`NDEBUG` is *not* defined. This:

- Removes the log line and its argument-formatting cost entirely from release
  builds (rather than just gating them at runtime), and lets the optimizer
  elide side-effect-free call-site argument evaluation too.
- Uses `NDEBUG` as the release hook, since that's what CMake's
  `Release`/`MinSizeRel`/`RelWithDebInfo` configurations define, and what
  Xcode's `Release` configuration defines by default for the iOS/podspec
  build — no build-file changes were needed to get the guard active on
  either platform. This mirrors the dev/release split React Native draws
  with `__DEV__`, per the issue's suggestion; I confirmed via grep that
  neither `NDEBUG` nor `__DEV__` has any existing convention elsewhere in
  this repo to reuse, so `NDEBUG` is introduced fresh here as the natural
  C/C++ analogue.
- Leaves `log_warning`/`log_error` completely untouched — they keep firing
  unconditionally in every build type, including `RelWithDebInfo`.

**Compile-time-only vs. the issue's "compile-time default with runtime
override" compromise:** I went with compile-time-only. This codebase has no
existing runtime config plumbing (no env-var reads, no JS-settable flag
reaching native code) for the logger to hook an override into, so adding one
would mean inventing new plumbing rather than reusing something established
— exactly the case the task's own fallback anticipates shipping the simpler
guard for. If a release-only bug ever needs this output back, the current
answer is to build a `Debug` or `RelWithDebInfo` artifact. That trade-off is
documented here rather than in a source comment, and is revisitable if it
turns out to be painful in practice.

## Inline comment guidelines (second commit)

Review feedback on the first commit was that its inline comments were far too
verbose — most of what they said is the kind of thing that belongs in a PR
description, which is where a `git blame` leads anyway and which doesn't have
to be maintained as the code around it moves.

- `Logger.hpp`'s comment block is down to the one fact the code itself
  doesn't convey: why the release no-op is `inline` in the header instead of
  an empty definition in `Logger.cpp`. The `NDEBUG`-means-release
  explanation, the `__DEV__` parallel, the compile-time-vs-runtime discussion
  and the `log_warning`/`log_error` note are all covered above instead.
- `Logger.cpp`'s cross-reference comment is gone; the `#ifndef NDEBUG` around
  the definition speaks for itself.
- `.claude/CLAUDE.md` gains a "Keep inline comments very brief" section
  encoding the rule for future sessions: default to no comment at all, write
  one only when it carries knowledge the code plus a `git blame` to the
  originating PR wouldn't give, and keep the survivors to a line or two.

## Verification

- `pnpm install && pnpm run build` — passes (TypeScript build is unaffected
  by this C++-only change).
- `pnpm exec prettier --check` on the touched changeset markdown — passes.
  (Prettier has no C++ parser, so it no-ops on `Logger.cpp`/`Logger.hpp`, per
  the repo's own formatting-hook note.)
- **Native compilation is not verified.** This is a Linux-only environment
  without the Android NDK or Apple toolchain, so I could not actually build
  `packages/host/android` or the podspec target through either `#ifdef`
  branch. The `#ifdef NDEBUG` / `#ifndef NDEBUG` structure is standard and
  low-risk, but an actual Android Release/Debug and iOS Release/Debug build
  should be run before merge to be sure.

## Changeset

Added `.changeset/release-debug-logging.md` as a `patch` for
`react-native-node-api`, since this changes observable logging behavior in
release builds for consumers. The repo is in `pre.json` pre-release mode
targeting `next`.

## Issue accuracy

I checked the issue's claims (line numbers, call sites) against current
`next` (`1966cb3`) — the `TODO` really is at `Logger.cpp` lines 66-72 as
described, and the call-site descriptions match exactly, so no correction to
the issue was needed.

---
🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01DaK9eAAF5G8wj6UT8VekAm