### PR TITLE
Route napi_fatal_exception through ErrorUtils.reportFatalError instead of aborting

### DIFF
--- a/.changeset/route-fatal-exception-through-errorutils.md
+++ b/.changeset/route-fatal-exception-through-errorutils.md
@@ -1,0 +1,5 @@
+---
+"react-native-node-api": minor
+---
+
+Route `napi_fatal_exception` through React Native's `ErrorUtils.reportFatalError` instead of unconditionally logging and calling `abort()`. This is what node-addon-api calls whenever an exception escapes a thread-safe-function callback, so a single throwing tsfn callback no longer hard-kills the app: in dev the error and its stack now surface in LogBox, in release RN's default handler rethrows into the native crash path, and apps can observe or handle it via `ErrorUtils.setGlobalHandler` — the moral equivalent of Node's `'uncaughtException'`. The previous stringify-and-abort behavior remains as a fallback for when `ErrorUtils`/`reportFatalError` isn't available (non-RN embedders, very early startup) or the handler itself throws.

--- a/packages/host/cpp/HermesNapiHost.cpp
+++ b/packages/host/cpp/HermesNapiHost.cpp
@@ -149,6 +149,63 @@ std::string describeError(napi_env env, napi_value err) {
   return "(unable to stringify the error value)";
 }
 
+// Stringifies `err`, logs it and aborts — the pre-#402 behavior, kept as the
+// fallback for whenever routing through ErrorUtils isn't possible.
+[[noreturn]] void abortWithFatalException(napi_env env, napi_value err) {
+  log_error("napi_fatal_exception: %s", describeError(env, err).c_str());
+  abort();
+}
+
+// Attempts to route `err` through React Native's
+// `global.ErrorUtils.reportFatalError`, the moral equivalent of Node's
+// process.emit('uncaughtException'): in dev this surfaces the real error and
+// stack in LogBox, in release it feeds RN's default rethrow-to-native-crash
+// handler, and apps can observe/handle it via ErrorUtils.setGlobalHandler.
+// Returns whether the error was routed successfully. On any failure —
+// ErrorUtils or reportFatalError absent/not the right type, or the call
+// itself throwing — clears any pending exception before returning false, so
+// the caller's fallback (which does its own Node-API calls) starts clean.
+bool tryReportFatalError(napi_env env, napi_value err) {
+  napi_value global = nullptr;
+  if (napi_get_global(env, &global) != napi_ok) {
+    return false;
+  }
+
+  napi_valuetype type = napi_undefined;
+  napi_value error_utils = nullptr;
+  if (napi_get_named_property(env, global, "ErrorUtils", &error_utils) !=
+          napi_ok ||
+      napi_typeof(env, error_utils, &type) != napi_ok ||
+      type != napi_object) {
+    return false;
+  }
+
+  napi_value report_fatal_error = nullptr;
+  if (napi_get_named_property(env, error_utils, "reportFatalError",
+                              &report_fatal_error) != napi_ok ||
+      napi_typeof(env, report_fatal_error, &type) != napi_ok ||
+      type != napi_function) {
+    return false;
+  }
+
+  napi_value argv[] = {err};
+  napi_status call_status = napi_call_function(
+      env, error_utils, report_fatal_error, 1, argv, nullptr);
+  if (call_status != napi_ok) {
+    // Most likely napi_pending_exception (the handler itself threw). Clear
+    // it so the fallback path — which makes further Node-API calls — isn't
+    // itself defeated by a stale pending exception.
+    bool is_pending = false;
+    if (napi_is_exception_pending(env, &is_pending) == napi_ok && is_pending) {
+      napi_value discarded = nullptr;
+      napi_get_and_clear_last_exception(env, &discarded);
+    }
+    return false;
+  }
+
+  return true;
+}
+
 } // namespace
 
 HostContext::HostContext(JsDispatcher dispatchToJs)
@@ -232,20 +289,37 @@ void HostContext::postTask(void *loop_data, void *task_data,
   }
 }
 
-void HostContext::fatalException(void *, napi_env env,
+void HostContext::fatalException(void *data, napi_env env,
                                  napi_value err) noexcept {
-  // Called on the JS thread by napi_fatal_exception(). Node routes this to
-  // process.emit('uncaughtException'); with no process object we log the
-  // error and abort — the same observable outcome as Hermes' null-host
-  // default, but surfaced through the host logger. `err` is only valid for
-  // the duration of this call, so it is stringified before returning.
-  // TODO: Route through React Native's error handling (ErrorUtils / LogBox),
-  // with abort() as the fallback, to get closer to Node's observable and
-  // handleable 'uncaughtException' — note node-addon-api calls
-  // napi_fatal_exception whenever an exception escapes a thread-safe
-  // function callback, so today a single throwing tsfn callback is fatal.
-  log_error("napi_fatal_exception: %s", describeError(env, err).c_str());
-  abort();
+  // Called on the JS thread by napi_fatal_exception() — Hermes returns
+  // napi_ok to the caller once this returns, matching Node, where emitting
+  // 'uncaughtException' returns to the caller and only aborts the process if
+  // no handler is installed (unlike napi_fatal_error, this hook has no
+  // noreturn contract). `err` is only valid for the duration of this call.
+  //
+  // Routed through ErrorUtils.reportFatalError, RN's own
+  // uncaughtException-equivalent: in dev the default handler shows LogBox
+  // with the real error and stack, in release it rethrows into the native
+  // crash path, and apps can observe/handle it via
+  // ErrorUtils.setGlobalHandler. node-addon-api calls napi_fatal_exception
+  // whenever an exception escapes a thread-safe function callback, so this
+  // is what stands between a throwing tsfn callback and a silent, unhandled
+  // abort.
+  auto *self = static_cast<HostContext *>(data);
+  if (self->inFatalException_) {
+    // Reentrant call: the ErrorUtils handler (or something it triggered)
+    // itself hit a fatal exception. Recursing back into reportFatalError
+    // could loop forever, so go straight to the fallback.
+    abortWithFatalException(env, err);
+  }
+  self->inFatalException_ = true;
+  bool routed = tryReportFatalError(env, err);
+  self->inFatalException_ = false;
+  if (!routed) {
+    // ErrorUtils/reportFatalError absent (non-RN embedder, or called before
+    // React Native has installed it) or the handler itself threw.
+    abortWithFatalException(env, err);
+  }
 }
 
 } // namespace callstack::react_native_node_api

--- a/packages/host/cpp/HermesNapiHost.hpp
+++ b/packages/host/cpp/HermesNapiHost.hpp
@@ -120,6 +120,12 @@ private:
 
   JsDispatcher dispatchToJs_;
   hermes_napi_host host_;
+  // Reentrancy guard for fatalException(): true for the duration of routing
+  // an error through ErrorUtils.reportFatalError. fatalException always runs
+  // synchronously on the JS thread (see its doc comment), so a plain member
+  // — no atomics or thread_local — is sufficient to detect a handler that
+  // itself triggers napi_fatal_exception before the outer call returns.
+  bool inFatalException_ = false;
 };
 
 } // namespace callstack::react_native_node_api


### PR DESCRIPTION
Closes #402.

## ⚠️ Untested — not compiled, not run on-device

This is genuinely correctness-sensitive C++ (fatal-error handling on the JS
thread) and **I could not build or exercise it in this environment**: this
worker has no Android NDK / Apple toolchain, so `HermesNapiHost.cpp` was
never compiled, let alone linked against a real `hermes_napi_host` and run
through the described on-device scenario (a test addon calling
`napi_fatal_exception` under a temporary `ErrorUtils.setGlobalHandler`).
Opening as a **draft** on purpose — please review the Node-API call sequence
and control flow carefully, and verify on-device, before merge.

## What changed

`HostContext::fatalException` (`packages/host/cpp/HermesNapiHost.cpp`)
previously stringified the error and called `abort()` unconditionally. Per
the issue, `napi_fatal_exception` (unlike the `noreturn` `napi_fatal_error`,
which is untouched — that's #428's file/territory, not modified here) is a
plain `napi_status`-returning function, and the pinned Hermes commit's
`hermes_napi_error.cpp` explicitly supports the host hook returning
normally. So the hook now:

1. Attempts `global.ErrorUtils.reportFatalError(err)` via
   `napi_get_global` → `napi_get_named_property(global, "ErrorUtils")` →
   `napi_get_named_property(errorUtils, "reportFatalError")` (type-checked
   at each step: must resolve to an object, then a function) →
   `napi_call_function`.
2. On success, returns normally — Hermes then returns `napi_ok` to the
   addon, matching Node's `process.emit('uncaughtException')` returning to
   the caller when a handler is installed.
3. On any failure — `ErrorUtils`/`reportFatalError` absent or the wrong
   type, or the call itself throwing — clears any pending exception
   (`napi_is_exception_pending` / `napi_get_and_clear_last_exception`) and
   falls back to the previous stringify + `log_error` + `abort()` path.
4. Guards reentrancy with a `bool` member on `HostContext`
   (`inFatalException_`): if the `ErrorUtils` handler itself triggers
   another `napi_fatal_exception`, the nested call skips straight to the
   fallback instead of recursing. `fatalException` always runs
   synchronously on the JS thread, so a plain member (no atomics/
   `thread_local`) is enough.

`HermesNapiHost.cpp`/`.hpp` remain free of React Native/JSI includes — all
routing goes through the passed `napi_env` using plain Node-API calls, all
of which (`napi_get_global`, `napi_get_named_property`, `napi_typeof`,
`napi_call_function`, `napi_is_exception_pending`,
`napi_get_and_clear_last_exception`) are already generated into
`weak-node-api` from the full `node-api-headers` symbol set (`napi_get_global`
itself was already used elsewhere in `CxxNodeApiHostModule.cpp`), so no
`weak-node-api` changes were needed.

Resulting semantics: in dev, RN's default handler shows LogBox with the
real error and stack; in release, it rethrows into the native crash path;
apps can install `ErrorUtils.setGlobalHandler` to observe/handle, the moral
equivalent of listening for `'uncaughtException'`.

## Changeset

Added `.changeset/route-fatal-exception-through-errorutils.md` as **minor**
for `react-native-node-api` — this is an observable behavior change for any
addon/app that relied on the previous immediate `abort()` (per repo
convention, this is a pre-release/`next`-targeted changeset per
`.changeset/pre.json`).

## What I did / did not verify

- ✅ `pnpm install && pnpm run build` (TypeScript project build) — clean.
- ✅ `pnpm exec prettier --check` on the new changeset file — clean.
- ✅ `pnpm run lint` — the only failures are 4 pre-existing
  `@typescript-eslint/no-unsafe-*` errors in `apps/test-app/App.tsx`,
  unrelated to this change (confirmed via `git diff origin/next` touching
  nothing in that file).
- ❌ **No C++ compilation** of `HermesNapiHost.cpp`/`.hpp` — no NDK/Apple
  toolchain available here.
- ❌ **No on-device test** of the actual routing behavior (LogBox
  appearing, `ErrorUtils.setGlobalHandler` receiving the error, the call
  returning `napi_ok`, the app surviving) — the issue's own suggested test.

## Recommended follow-up

The issue suggests a test addon that calls `napi_fatal_exception` under a
temporary `ErrorUtils.setGlobalHandler`. `packages/node-addon-examples`
already has a `tests/threadsafe-function` addon that could be a template,
but I deliberately did **not** add a new native test addon myself: writing
untested native C++ in an environment where I can't compile or run it adds
more unverified surface area rather than de-risking this change. I'd
recommend adding that on-device test as a fast-follow once this PR's core
logic has been reviewed/verified.

## Files touched

- `packages/host/cpp/HermesNapiHost.cpp`
- `packages/host/cpp/HermesNapiHost.hpp`
- `.changeset/route-fatal-exception-through-errorutils.md`

(`packages/host/cpp/RuntimeNodeApi.cpp` was intentionally left untouched —
that's issue #428's territory.)

---
🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01DaK9eAAF5G8wj6UT8VekAm

---
_Generated by [Claude Code](https://claude.ai/code/session_01DaK9eAAF5G8wj6UT8VekAm)_