### PR TITLE
fix(cmake-rn): let ANDROID_STL be overridden via --define

### DIFF
--- a/.changeset/gentle-pandas-learn.md
+++ b/.changeset/gentle-pandas-learn.md
@@ -1,0 +1,15 @@
+---
+"cmake-rn": minor
+---
+
+Let a consumer override the Android `ANDROID_STL` CMake cache variable via
+the existing `-D`/`--define` option (e.g. `--define ANDROID_STL=c++_static`).
+It still defaults to `c++_shared`, matching what React Native itself uses,
+but an addon that must match a prebuilt third-party dependency's STL, or one
+that's genuinely self-contained, can now ask for a different value.
+
+This also fixes an ordering bug where a `--define` targeting any of the
+Android platform's own default CMake variables (including `ANDROID_STL`) was
+silently discarded: our hardcoded defaults were appended to the CMake
+command line _after_ the user-provided `-D` arguments, and CMake resolves a
+cache variable set multiple times via `-D` to its last occurrence.

--- a/packages/cmake-rn/src/platforms/android.test.ts
+++ b/packages/cmake-rn/src/platforms/android.test.ts
@@ -1,0 +1,60 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { toDefineArguments } from "../helpers.js";
+import { buildCommonDefinitions } from "./android.js";
+
+function baseArgs(
+  overrides: Partial<Parameters<typeof buildCommonDefinitions>[0]> = {},
+) {
+  return {
+    configuration: "Release" as const,
+    ndkPath: "/opt/ndk",
+    androidSdkVersion: "24",
+    ccachePath: null,
+    define: [],
+    ...overrides,
+  };
+}
+
+describe("buildCommonDefinitions", () => {
+  it("defaults ANDROID_STL to c++_shared", () => {
+    const args = toDefineArguments(buildCommonDefinitions(baseArgs()));
+    const index = args.indexOf("-D");
+    assert(index >= 0);
+    assert(args.includes("ANDROID_STL=c++_shared"));
+  });
+
+  it("lets a consumer override ANDROID_STL via --define", () => {
+    // CMake resolves a cache variable passed multiple times via `-D` to its
+    // *last* occurrence on the command line, so what matters is which
+    // ANDROID_STL entry comes last - not merely that c++_static is present.
+    const args = toDefineArguments(
+      buildCommonDefinitions(
+        baseArgs({ define: [{ ANDROID_STL: "c++_static" }] }),
+      ),
+    );
+    const stlEntries = args.filter((arg) => arg.startsWith("ANDROID_STL="));
+    assert.deepEqual(stlEntries, [
+      "ANDROID_STL=c++_shared",
+      "ANDROID_STL=c++_static",
+    ]);
+  });
+
+  it("applies the user's --define after (so it wins over) every default", () => {
+    const definitions = buildCommonDefinitions(
+      baseArgs({ define: [{ ANDROID_STL: "c++_static" }] }),
+    );
+    // The user-provided define must be the last entry, since CMake resolves
+    // a -D variable passed multiple times to its last occurrence.
+    assert.deepEqual(definitions.at(-1), { ANDROID_STL: "c++_static" });
+  });
+
+  it("includes ccache launcher variables when a ccache path is given", () => {
+    const args = toDefineArguments(
+      buildCommonDefinitions(baseArgs({ ccachePath: "/usr/bin/ccache" })),
+    );
+    assert(args.includes("CMAKE_C_COMPILER_LAUNCHER=/usr/bin/ccache"));
+    assert(args.includes("CMAKE_CXX_COMPILER_LAUNCHER=/usr/bin/ccache"));
+  });
+});

--- a/packages/cmake-rn/src/platforms/android.ts
+++ b/packages/cmake-rn/src/platforms/android.ts
@@ -91,6 +91,56 @@ function getNdkLlvmBinPath(ndkPath: string) {
   return path.join(prebuiltPath, platforms[0], "bin");
 }
 
+const DEFAULT_ANDROID_STL = "c++_shared";
+
+/**
+ * Builds the list of CMake cache variable definitions common to every
+ * triplet's configure step.
+ *
+ * `define` (populated from the repeatable `-D`/`--define` CLI option) is
+ * spread last, so a consumer's explicit `-D ANDROID_STL=c++_static` (or any
+ * other variable set here by default) takes precedence over our own
+ * defaults: CMake resolves a cache variable passed multiple times via `-D`
+ * to its last occurrence on the command line.
+ */
+export function buildCommonDefinitions({
+  configuration,
+  ndkPath,
+  androidSdkVersion,
+  ccachePath,
+  define,
+}: {
+  configuration: BaseOpts["configuration"];
+  ndkPath: string;
+  androidSdkVersion: string;
+  ccachePath: BaseOpts["ccachePath"];
+  define: BaseOpts["define"];
+}) {
+  return [
+    {
+      CMAKE_BUILD_TYPE: configuration,
+      CMAKE_SYSTEM_NAME: "Android",
+      // "CMAKE_INSTALL_PREFIX": installPath,
+      CMAKE_MAKE_PROGRAM: "ninja",
+      ANDROID_NDK: ndkPath,
+      ANDROID_TOOLCHAIN: "clang",
+      ANDROID_PLATFORM: androidSdkVersion,
+      // Defaults to c++_shared, matching what React Native itself uses.
+      // Override with -D/--define ANDROID_STL=c++_static (or another value
+      // accepted by the NDK's CMake toolchain) when an addon must match a
+      // prebuilt third-party dependency's STL.
+      ANDROID_STL: DEFAULT_ANDROID_STL,
+    },
+    ccachePath
+      ? {
+          CMAKE_C_COMPILER_LAUNCHER: ccachePath,
+          CMAKE_CXX_COMPILER_LAUNCHER: ccachePath,
+        }
+      : {},
+    ...define,
+  ];
+}
+
 export const platform: Platform<Triplet[], AndroidOpts> = {
   id: "android",
   name: "Android",
@@ -140,26 +190,13 @@ export const platform: Platform<Triplet[], AndroidOpts> = {
     const ndkPath = getNdkPath(ndkVersion);
     const toolchainPath = getNdkToolchainPath(ndkPath);
 
-    const commonDefinitions = [
-      ...define,
-      {
-        CMAKE_BUILD_TYPE: configuration,
-        CMAKE_SYSTEM_NAME: "Android",
-        // "CMAKE_INSTALL_PREFIX": installPath,
-        CMAKE_MAKE_PROGRAM: "ninja",
-        ANDROID_NDK: ndkPath,
-        ANDROID_TOOLCHAIN: "clang",
-        ANDROID_PLATFORM: androidSdkVersion,
-        // TODO: Make this configurable
-        ANDROID_STL: "c++_shared",
-      },
-      ccachePath
-        ? {
-            CMAKE_C_COMPILER_LAUNCHER: ccachePath,
-            CMAKE_CXX_COMPILER_LAUNCHER: ccachePath,
-          }
-        : {},
-    ];
+    const commonDefinitions = buildCommonDefinitions({
+      configuration,
+      ndkPath,
+      androidSdkVersion,
+      ccachePath,
+      define,
+    });
 
     await Promise.all(
       triplets.map(async ({ triplet, spawn }) => {


### PR DESCRIPTION
Addresses the Android half of #418 ("Make the hardcoded `ANDROID_STL` build setting configurable"). The Apple half (`CODE_SIGNING_ALLOWED`) is a separate PR.

## What was wrong

`ANDROID_STL` was hardcoded to `c++_shared` in `packages/cmake-rn/src/platforms/android.ts`, with a `// TODO: Make this configurable` comment and no way for a consumer to override it — a problem for an addon that's genuinely self-contained (wants `c++_static`) or, more importantly, one that must match a prebuilt third-party dependency's STL.

## Findings re: #227

`cmake-rn` already has a generic `-D`/`--define` option (added in #332, well before #227 was filed) that passes arbitrary CMake cache variables through to the configure step — exactly the kind of pass-through #227 asks for, and it already covers `ANDROID_STL` for free... in principle.

In practice it didn't work for the Android platform's own default variables: `commonDefinitions` spread the user's `define` array **before** the hardcoded object containing `ANDROID_STL: "c++_shared"`. Since CMake resolves a cache variable passed multiple times via `-D` to its **last** occurrence on the command line, our hardcoded default always silently overrode a user's `--define ANDROID_STL=...`.

## The fix

Reordered so the user's `--define` entries are applied **last**, after our own defaults (`ANDROID_STL` included). The default (`c++_shared`, matching what React Native itself uses) is unchanged; a consumer can now do:

```
cmake-rn --define ANDROID_STL=c++_static
```

Extracted the definitions-building logic into an exported, pure `buildCommonDefinitions` function so it's independently testable without mocking the NDK/filesystem, and added unit tests covering the default value and the override-precedence fix.

Given the existing pass-through option already substantially covers this, no new dedicated `--android-stl`-style flag was added — that would just duplicate `--define`.

## Validation
- `pnpm install && pnpm run build`
- `pnpm --filter cmake-rn run test`
- `pnpm exec eslint packages/cmake-rn/src/platforms/android.ts packages/cmake-rn/src/platforms/android.test.ts`
- `pnpm exec prettier --check` on touched files
- Added a `minor` changeset for `cmake-rn` (new capability, backward compatible — default unchanged)

---
🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01DaK9eAAF5G8wj6UT8VekAm

---
_Generated by [Claude Code](https://claude.ai/code/session_01DaK9eAAF5G8wj6UT8VekAm)_