### PR TITLE
Drop the host's shadowing implementations of runtime Node-API functions

### DIFF
--- a/.changeset/drop-shadowing-napi-shims.md
+++ b/.changeset/drop-shadowing-napi-shims.md
@@ -1,0 +1,26 @@
+---
+"react-native-node-api": patch
+---
+
+Drop the host's shadowing implementations of Node-API functions that Hermes'
+first-party Node-API already provides, so addons observe Hermes' behavior
+instead of the host's older shims:
+
+- `napi_get_node_version` now reports Hermes' own version (release name
+  `"hermes"`) instead of unconditionally failing with `napi_generic_failure`.
+- `napi_is_buffer` now returns `true` only for `Uint8Array`, matching Node,
+  instead of any `ArrayBuffer`/`TypedArray`.
+- `napi_get_buffer_info` now returns `napi_invalid_arg` for non-`Uint8Array`
+  values, matching Node, instead of `napi_ok` with zeroed output.
+- `napi_create_buffer_copy` now writes a non-`NULL` `result_data` argument, as
+  documented, instead of silently ignoring it.
+- `napi_create_buffer`, `napi_create_external_buffer` and `napi_get_version`
+  are unchanged in observable behavior, now served by Hermes directly.
+
+This also fixes a bug where calling `napi_get_buffer_info` on a non-`Uint8Array`
+typed array (e.g. a `Float64Array`) left a process-global flag corrupted, so
+that every subsequent `napi_create_buffer`/`napi_create_external_buffer` call
+produced the wrong typed array view.
+
+`napi_fatal_error` keeps its host-side implementation, so fatal Node-API
+errors keep reaching logcat on Android instead of only stderr.

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -154,7 +154,7 @@ jobs:
           ctest --test-dir build --output-on-failure
         working-directory: packages/weak-node-api
   host-cpp-tests:
-    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/next' || contains(github.event.pull_request.labels.*.name, 'host')
+    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/next' || contains(github.event.pull_request.labels.*.name, 'Host 🏡')
     strategy:
       fail-fast: false
       matrix:

--- a/packages/host/cpp/RuntimeNodeApi.cpp
+++ b/packages/host/cpp/RuntimeNodeApi.cpp
@@ -1,125 +1,12 @@
 #include "RuntimeNodeApi.hpp"
 #include "Logger.hpp"
-#include "Versions.hpp"
-#include <string>
 
-auto ArrayType = napi_uint8_array;
+#include <cstdlib>
 
 namespace callstack::react_native_node_api {
 
-napi_status napi_create_buffer(napi_env env, size_t length, void **data,
-                               napi_value *result) {
-  napi_value buffer;
-  if (const auto status = napi_create_arraybuffer(env, length, data, &buffer);
-      status != napi_ok) {
-    return status;
-  }
-
-  // Warning: The returned data structure does not fully align with the
-  // characteristics of a Buffer.
-  // @see
-  // https://github.com/callstackincubator/react-native-node-api/issues/171
-  return napi_create_typedarray(env, ArrayType, length, buffer, 0, result);
-}
-
-napi_status napi_create_buffer_copy(napi_env env, size_t length,
-                                    const void *data, void **result_data,
-                                    napi_value *result) {
-  if (!length || !data || !result) {
-    return napi_invalid_arg;
-  }
-
-  void *buffer = nullptr;
-  if (const auto status = callstack::react_native_node_api::napi_create_buffer(
-          env, length, &buffer, result);
-      status != napi_ok) {
-    return status;
-  }
-
-  std::memcpy(buffer, data, length);
-  return napi_ok;
-}
-
-napi_status napi_is_buffer(napi_env env, napi_value value, bool *result) {
-  if (!result) {
-    return napi_invalid_arg;
-  }
-
-  if (!value) {
-    *result = false;
-    return napi_ok;
-  }
-
-  napi_valuetype type{};
-  if (const auto status = napi_typeof(env, value, &type); status != napi_ok) {
-    return status;
-  }
-
-  if (type != napi_object && type != napi_external) {
-    *result = false;
-    return napi_ok;
-  }
-
-  auto isArrayBuffer{false};
-  if (const auto status = napi_is_arraybuffer(env, value, &isArrayBuffer);
-      status != napi_ok) {
-    return status;
-  }
-  auto isTypedArray{false};
-  if (const auto status = napi_is_typedarray(env, value, &isTypedArray);
-      status != napi_ok) {
-    return status;
-  }
-
-  *result = isArrayBuffer || isTypedArray;
-  return napi_ok;
-}
-
-napi_status napi_get_buffer_info(napi_env env, napi_value value, void **data,
-                                 size_t *length) {
-  if (!data || !length) {
-    return napi_invalid_arg;
-  }
-  *data = nullptr;
-  *length = 0;
-  if (!value) {
-    return napi_ok;
-  }
-
-  auto isArrayBuffer{false};
-  if (const auto status = napi_is_arraybuffer(env, value, &isArrayBuffer);
-      status == napi_ok && isArrayBuffer) {
-    return napi_get_arraybuffer_info(env, value, data, length);
-  }
-
-  auto isTypedArray{false};
-  if (const auto status = napi_is_typedarray(env, value, &isTypedArray);
-      status == napi_ok && isTypedArray) {
-    return napi_get_typedarray_info(env, value, &ArrayType, length, data,
-                                    nullptr, nullptr);
-  }
-
-  return napi_ok;
-}
-
-napi_status
-napi_create_external_buffer(napi_env env, size_t length, void *data,
-                            node_api_basic_finalize basic_finalize_cb,
-                            void *finalize_hint, napi_value *result) {
-  napi_value buffer;
-  if (const auto status = napi_create_external_arraybuffer(
-          env, data, length, basic_finalize_cb, finalize_hint, &buffer);
-      status != napi_ok) {
-    return status;
-  }
-
-  // Warning: The returned data structure does not fully align with the
-  // characteristics of a Buffer.
-  // @see
-  // https://github.com/callstackincubator/react-native-node-api/issues/171
-  return napi_create_typedarray(env, ArrayType, length, buffer, 0, result);
-}
-
+// See the comment on the declaration in RuntimeNodeApi.hpp for why this
+// deliberately shadows Hermes' own napi_fatal_error.
 void napi_fatal_error(const char *location, size_t location_len,
                       const char *message, size_t message_len) {
   if (location && location_len) {
@@ -130,25 +17,6 @@ void napi_fatal_error(const char *location, size_t location_len,
               message);
   }
   abort();
-}
-
-napi_status napi_get_node_version(node_api_basic_env env,
-                                  const napi_node_version **result) {
-  if (!result) {
-    return napi_invalid_arg;
-  }
-
-  *result = nullptr;
-  return napi_generic_failure;
-}
-
-napi_status napi_get_version(node_api_basic_env env, uint32_t *result) {
-  if (!result) {
-    return napi_invalid_arg;
-  }
-
-  *result = NAPI_VERSION;
-  return napi_ok;
 }
 
 } // namespace callstack::react_native_node_api

--- a/packages/host/cpp/RuntimeNodeApi.hpp
+++ b/packages/host/cpp/RuntimeNodeApi.hpp
@@ -3,30 +3,30 @@
 #include "node_api.h"
 
 namespace callstack::react_native_node_api {
-napi_status napi_create_buffer(napi_env env, size_t length, void **data,
-                               napi_value *result);
 
-napi_status napi_create_buffer_copy(napi_env env, size_t length,
-                                    const void *data, void **result_data,
-                                    napi_value *result);
-
-napi_status napi_is_buffer(napi_env env, napi_value value, bool *result);
-
-napi_status napi_get_buffer_info(napi_env env, napi_value value, void **data,
-                                 size_t *length);
-
-napi_status
-napi_create_external_buffer(napi_env env, size_t length, void *data,
-                            node_api_basic_finalize basic_finalize_cb,
-                            void *finalize_hint, napi_value *result);
-
+// Hermes' first-party Node-API implementation (API/napi/hermes_napi.cpp)
+// already defines napi_fatal_error, routing it through hermes_fatal() ->
+// llvh::report_fatal_error(), which writes to stderr. On Android stderr is
+// not logcat, so that message would be lost exactly when it matters most:
+// right before the process aborts.
+//
+// This declaration is deliberately kept so it shadows Hermes' symbol: the
+// generated injector (scripts/generate-injector.mts) resolves each
+// NodeApiHost field by unqualified name inside
+// `namespace callstack::react_native_node_api`, and this header is included
+// there, so unqualified lookup finds this declaration before it would reach
+// Hermes' exported symbol. That lets the host's implementation win, which
+// logs via the host logger to logcat with the "NodeApiHost" tag (see
+// Logger.cpp) before aborting.
+//
+// Every other Node-API function the host used to shim here (buffers,
+// napi_get_version, napi_get_node_version) was removed in favor of letting
+// the same lookup fall through to Hermes' own implementation - see
+// https://github.com/callstackincubator/react-native-node-api/issues/428.
+// Do not remove this one the same way without replacing the logcat routing.
 void __attribute__((noreturn)) napi_fatal_error(const char *location,
                                                 size_t location_len,
                                                 const char *message,
                                                 size_t message_len);
 
-napi_status napi_get_node_version(node_api_basic_env env,
-                                  const napi_node_version **result);
-
-napi_status napi_get_version(node_api_basic_env env, uint32_t *result);
 } // namespace callstack::react_native_node_api


### PR DESCRIPTION
## Summary

Hermes' first-party Node-API (adopted in #372, wired up via `hermes_napi_host` in #398) already implements the entire runtime surface, including buffers, `napi_fatal_error`, `napi_get_version` and `napi_get_node_version`. But `packages/host/cpp/RuntimeNodeApi.{cpp,hpp}` still defined eight of these — and won, because the generated injector (`packages/host/scripts/generate-injector.mts`) resolves each `NodeApiHost` field by unqualified name inside `namespace callstack::react_native_node_api`, and `RuntimeNodeApi.hpp` is included there. So unqualified lookup found the host's shim before it ever reached Hermes' exported symbol.

This PR removes seven of those eight functions, letting the unqualified-name lookup fall through to Hermes' own implementations (the same mechanism every *other* Node-API function in this codebase already relies on — `RuntimeNodeApi.cpp` itself calls `napi_create_arraybuffer`, `napi_typeof`, etc. without defining them, and those already resolve to Hermes today):

- `napi_create_buffer`, `napi_create_buffer_copy`, `napi_create_external_buffer`, `napi_get_buffer_info`, `napi_is_buffer` — dropped.
- `napi_get_version` — dropped (Hermes' answer is identical, `NAPI_VERSION`).
- `napi_get_node_version` — dropped. Closes #67: addons now get Hermes' actual version instead of `napi_generic_failure`.
- `napi_fatal_error` — **kept**, with a comment on the declaration explaining why: Hermes routes it to stderr, which isn't logcat on Android, while the host's version reaches logcat via the `NodeApiHost` logger tag.

This also removes two bugs the shims carried:
1. `napi_get_buffer_info` overwrote a mutable global (`ArrayType`) used by `napi_create_buffer`/`napi_create_external_buffer`; calling it on a non-`Uint8Array` typed array (e.g. `Float64Array`) corrupted every later buffer creation on that process, and raced across runtimes.
2. `napi_create_buffer_copy` accepted `result_data` but never wrote it.

`napi_is_buffer`/`napi_get_buffer_info` also become stricter, matching Node: `true`/`napi_ok` only for `Uint8Array`, `napi_invalid_arg` otherwise (previously any `ArrayBuffer`/`TypedArray`). This is an intentional, documented behavior change (see the changeset), and also tightens #171.

`RuntimeNodeApi.{cpp,hpp}` keep their own translation unit rather than folding into `Logger`-adjacent code — the file now holds exactly the one shim the host deliberately keeps shadowing, and renaming would touch the generated injector, `CMakeLists.txt`, and the podspec's glob for no functional benefit. `packages/host/android/CMakeLists.txt` needed no changes as a result.

A changeset (`patch`) documents the observable behavior change for `napi_get_node_version` and the buffer functions.

## Why this is safe (reachability of Hermes' symbols)

I verified, source-level, that removing the host's declarations doesn't strand these calls:
- The generated injector's `NodeApiHost { .name = name, ... }` entries are produced for *every* Node-API function from `node-api-headers` (`packages/weak-node-api/src/node-api-functions.ts`), regardless of whether the host defines it — this list is unaffected by this change.
- `RuntimeNodeApi.cpp` already calls many Node-API functions (`napi_create_arraybuffer`, `napi_typeof`, `napi_is_arraybuffer`, `napi_get_arraybuffer_info`, `napi_get_typedarray_info`, `napi_create_external_arraybuffer`) without defining them anywhere in this repo — those already resolve, at link time, to Hermes' exported symbols today. Once `RuntimeNodeApi.hpp` no longer declares the seven removed functions inside `namespace callstack::react_native_node_api`, unqualified lookup for them falls through to the same global-namespace declarations from `node_api.h` (already used identically for the calls above) and links against Hermes' `hermesvm`/xcframework the same way.

## Verified

- `pnpm install && pnpm run build` — passes.
- `pnpm --filter react-native-node-api run test` — passes except three pre-existing, unrelated failures in `path-utils.test.ts` around unreadable-file/permission handling; confirmed those fail identically on unmodified `origin/next` in this sandbox (it runs as `root`, which bypasses the permission checks the tests rely on).
- `pnpm exec eslint packages/host` and `pnpm exec prettier --check` on touched files — clean.
- Checked no other files in the repo reference the removed functions or `RuntimeNodeApi` symbols outside the two edited files.

## Not verified (needs a real device/toolchain)

- **Native C++ compilation** — no Android/iOS toolchain is available in this sandbox. The change was reviewed at the source level only.
- **`packages/node-addon-examples/tests/buffers` still passing on device** — reviewed the test source (`addon.c`/`addon.js`) against both the old and new (Hermes) semantics; every buffer the test creates goes through `napi_create_buffer`/`napi_create_external_buffer` (producing real `Uint8Array`s under both implementations), and its one non-buffer check (`invalidObjectAsBuffer`) passes `NULL` for both `data`/`length`, which trips `napi_invalid_arg` under either implementation. So this should still pass, but **this checklist item from #428 remains pending human/CI verification on an actual device**.

Closes #428, closes #67.

---
🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01DaK9eAAF5G8wj6UT8VekAm

---
_Generated by [Claude Code](https://claude.ai/code/session_01DaK9eAAF5G8wj6UT8VekAm)_