### PR TITLE
docs: instruct Claude Code to attach CI labels when opening PRs

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,55 @@
+# CLAUDE.md (`.claude/`)
+
+Guidance specific to Claude Code sessions that open pull requests against this
+repository (including automated/scheduled sessions). See the root `CLAUDE.md`
+and `AGENTS.md` for everything else.
+
+## Attach CI labels when you open a PR
+
+`.github/workflows/check.yml`'s `pull_request` trigger only fires on
+`opened`, `synchronize` and `reopened` — **not** `labeled`. Several of its
+jobs are gated behind a label check evaluated against that triggering
+event's payload, e.g.:
+
+```yaml
+if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/next' || contains(github.event.pull_request.labels.*.name, 'host')
+```
+
+A label added after the PR is already open does nothing on its own — there
+is no new `opened`/`synchronize`/`reopened` event for the workflow to
+re-evaluate against, so the gated job silently never runs, and that gap is
+easy to miss since the Check run still shows green (the job wasn't
+skipped-and-failed, it just never triggered).
+
+The `create_pull_request` GitHub MCP tool has no `labels` parameter, so
+labels can only be attached in a follow-up call after the PR exists — which
+is exactly the case above. **Whenever you open a PR here:**
+
+1. Decide which of the labels below apply, based on what the diff touches.
+2. Attach them immediately after creating the PR (e.g. `issue_write` with
+   `method: "update"`, or the equivalent `gh pr edit --add-label`).
+3. Push one more commit to the branch — even a trivial or `--allow-empty`
+   one — so a `synchronize` event fires and the gated jobs actually run with
+   the labels now present. Labeling without this step means the relevant CI
+   never runs before merge.
+
+## Label → job map
+
+| Label           | Gated job(s)                                                                                                                                                                              | Attach when the diff touches                                                                                                                                                                              |
+| --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `host`          | Host C++ tests                                                                                                                                                                            | `packages/host/cpp/`, `packages/host/android/CMakeLists.txt`, the generated injector, or anything in `packages/weak-node-api` that the host links against                                                 |
+| `Apple 🍎`      | iOS test app build/run                                                                                                                                                                    | iOS/macOS/tvOS/visionOS build config, XCFrameworks, Cocoapods, Xcode project files, or any change to Node-API behavior addons rely on (buffers, fatal-error handling, etc.) that device tests would catch |
+| `Android 🤖`    | Android test app build/run (self-hosted runner; currently label-gated even on `main`/`next`, see the `if:` comment in `check.yml` — check whether that's still true before relying on it) | Gradle, NDK, Android SDK, `.android.node` packaging, or the same cross-platform Node-API behavior changes as above                                                                                        |
+| `MacOS 💻`      | macOS test app                                                                                                                                                                            | `react-native-macos`-specific code paths                                                                                                                                                                  |
+| `Ferric 🦀`     | Ferric Apple triplets build                                                                                                                                                               | `packages/ferric`, `packages/ferric-example`, or anything napi-rs/Cargo related                                                                                                                           |
+| `weak-node-api` | weak-node-api tests                                                                                                                                                                       | `packages/weak-node-api`                                                                                                                                                                                  |
+
+A PR can need more than one label — e.g. a change to `RuntimeNodeApi.cpp`
+that alters buffer semantics warrants `host` plus `Apple 🍎` and
+`Android 🤖`, since the actual behavior change can only be verified on a
+real device.
+
+When in doubt, prefer attaching a label and letting the job run (mirroring
+what the label's own description says on GitHub) over guessing it isn't
+needed — a job that runs and passes costs a bit of CI time; a real device
+regression that ships because the label was skipped costs much more.

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -12,7 +12,7 @@ jobs are gated behind a label check evaluated against that triggering
 event's payload, e.g.:
 
 ```yaml
-if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/next' || contains(github.event.pull_request.labels.*.name, 'host')
+if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/next' || contains(github.event.pull_request.labels.*.name, 'Host 🏡')
 ```
 
 A label added after the PR is already open does nothing on its own — there
@@ -20,6 +20,14 @@ is no new `opened`/`synchronize`/`reopened` event for the workflow to
 re-evaluate against, so the gated job silently never runs, and that gap is
 easy to miss since the Check run still shows green (the job wasn't
 skipped-and-failed, it just never triggered).
+
+The label name in the `if:` condition has to match a real, currently-existing
+GitHub label exactly (name and emoji). `host-cpp-tests` checked for a label
+literally named `host` for a while, when the repository's real label was
+`Host 🏡` — the condition never matched anything anyone would actually apply,
+so the job silently only ran on pushes to `main`/`next`. Confirm the label
+exists (e.g. via the GitHub MCP `get_label` tool) before trusting a condition
+or table like the one below.
 
 The `create_pull_request` GitHub MCP tool has no `labels` parameter, so
 labels can only be attached in a follow-up call after the PR exists — which
@@ -37,7 +45,7 @@ is exactly the case above. **Whenever you open a PR here:**
 
 | Label           | Gated job(s)                                                                                                                                                                              | Attach when the diff touches                                                                                                                                                                              |
 | --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `host`          | Host C++ tests                                                                                                                                                                            | `packages/host/cpp/`, `packages/host/android/CMakeLists.txt`, the generated injector, or anything in `packages/weak-node-api` that the host links against                                                 |
+| `Host 🏡`       | Host C++ tests                                                                                                                                                                            | `packages/host/cpp/`, `packages/host/android/CMakeLists.txt`, the generated injector, or anything in `packages/weak-node-api` that the host links against                                                 |
 | `Apple 🍎`      | iOS test app build/run                                                                                                                                                                    | iOS/macOS/tvOS/visionOS build config, XCFrameworks, Cocoapods, Xcode project files, or any change to Node-API behavior addons rely on (buffers, fatal-error handling, etc.) that device tests would catch |
 | `Android 🤖`    | Android test app build/run (self-hosted runner; currently label-gated even on `main`/`next`, see the `if:` comment in `check.yml` — check whether that's still true before relying on it) | Gradle, NDK, Android SDK, `.android.node` packaging, or the same cross-platform Node-API behavior changes as above                                                                                        |
 | `MacOS 💻`      | macOS test app                                                                                                                                                                            | `react-native-macos`-specific code paths                                                                                                                                                                  |
@@ -45,7 +53,7 @@ is exactly the case above. **Whenever you open a PR here:**
 | `weak-node-api` | weak-node-api tests                                                                                                                                                                       | `packages/weak-node-api`                                                                                                                                                                                  |
 
 A PR can need more than one label — e.g. a change to `RuntimeNodeApi.cpp`
-that alters buffer semantics warrants `host` plus `Apple 🍎` and
+that alters buffer semantics warrants `Host 🏡` plus `Apple 🍎` and
 `Android 🤖`, since the actual behavior change can only be verified on a
 real device.
 


### PR DESCRIPTION
## Summary

`.github/workflows/check.yml`'s `pull_request` trigger fires only on `opened`, `synchronize` and `reopened` — not `labeled`. Several jobs are gated on a label being present in that triggering event's payload (`host`, `Apple 🍎`, `Android 🤖`, `MacOS 💻`, `Ferric 🦀`, `weak-node-api`). Since `create_pull_request` (the GitHub MCP tool used to open PRs) has no `labels` parameter, labels can only be attached via a follow-up call after the PR already exists — which means the gated jobs silently never run against that PR unless something pushes a new commit afterward.

This surfaced concretely on #434: it touches `packages/host/cpp/RuntimeNodeApi.{cpp,hpp}` and needed `host`/`Apple 🍎`/`Android 🤖` for real coverage, but the labels were only attached after the PR was opened, so the Check run had already evaluated those `if:` conditions without them.

Adds `.claude/CLAUDE.md` documenting:
- why a label added after PR creation doesn't retroactively trigger gated jobs
- a label → job → "attach when the diff touches…" table for the six label-gated jobs
- the required follow-up: attach labels, then push one more commit (even a trivial/empty one) so a `synchronize` event re-evaluates the gated jobs with labels present

This is a base against `main` per the request that prompted it — not `next`, since the repo's other content conventions live there but `.claude/` is tooling/agent-instruction surface rather than package code.

## Testing

- `pnpm exec prettier --check .claude/CLAUDE.md` — passes (also reformatted the table via `--write` before committing).

---
🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01DaK9eAAF5G8wj6UT8VekAm

---
_Generated by [Claude Code](https://claude.ai/code/session_01DaK9eAAF5G8wj6UT8VekAm)_