### PR TITLE
Upgrade bufout to v1.0.0 and remove EventEmitter listener limits

### DIFF
--- a/.changeset/bufout-one-point-oh.md
+++ b/.changeset/bufout-one-point-oh.md
@@ -1,0 +1,16 @@
+---
+"@react-native-node-api/cli-utils": patch
+"react-native-node-api": patch
+"cmake-rn": patch
+"ferric-cli": patch
+---
+
+Upgrade `bufout` to v1.0.0, which keeps the number of listeners on the process
+and the output streams constant regardless of how many children are spawned
+concurrently: a single shared `exit`/`SIGINT` listener is attached only while
+children are running, and every child pipes into one shared pass-through per
+destination stream.
+
+That removes the reason for the CLIs to raise `EventEmitter.defaultMaxListeners`
+to 100, so those assignments are gone and Node's default limit again applies —
+restoring the leak warning it exists to give.

--- a/packages/cli-utils/package.json
+++ b/packages/cli-utils/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@commander-js/extra-typings": "^14.0.0",
-    "bufout": "^0.3.2",
+    "bufout": "^1.0.0",
     "chalk": "^5.4.1",
     "commander": "^14.0.1",
     "ora": "^8.2.0",

--- a/packages/cmake-rn/src/cli.ts
+++ b/packages/cmake-rn/src/cli.ts
@@ -1,7 +1,6 @@
 import assert from "node:assert/strict";
 import path from "node:path";
 import fs from "node:fs";
-import { EventEmitter } from "node:events";
 
 import {
   chalk,
@@ -21,9 +20,6 @@ import {
 } from "./platforms.js";
 import { Platform } from "./platforms/types.js";
 import { getCcachePath } from "./ccache.js";
-
-// We're attaching a lot of listeners when spawning in parallel
-EventEmitter.defaultMaxListeners = 100;
 
 const verboseOption = new Option(
   "--verbose",

--- a/packages/ferric/src/run.ts
+++ b/packages/ferric/src/run.ts
@@ -1,8 +1,3 @@
-import EventEmitter from "node:events";
-
 import { program } from "./program.js";
-
-// We're attaching a lot of listeners when spawning in parallel
-EventEmitter.defaultMaxListeners = 100;
 
 program.parseAsync(process.argv).catch(console.error);

--- a/packages/host/src/node/cli/program.ts
+++ b/packages/host/src/node/cli/program.ts
@@ -1,6 +1,5 @@
 import assert from "node:assert/strict";
 import path from "node:path";
-import { EventEmitter } from "node:stream";
 
 import {
   Command,
@@ -27,9 +26,6 @@ import { packageNameOption, pathSuffixOption } from "./options";
 import { linkModules, pruneLinkedModules, ModuleLinker } from "./link-modules";
 import { ensureXcodeBuildPhase, createAppleLinker } from "./apple";
 import { linkAndroidDir } from "./android";
-
-// We're attaching a lot of listeners when spawning in parallel
-EventEmitter.defaultMaxListeners = 100;
 
 export const program = new Command("react-native-node-api").addCommand(
   vendorHermes,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -144,8 +144,8 @@ importers:
         specifier: ^14.0.0
         version: 14.0.0(commander@14.0.3)
       bufout:
-        specifier: ^0.3.2
-        version: 0.3.4
+        specifier: ^1.0.0
+        version: 1.0.0
       chalk:
         specifier: ^5.4.1
         version: 5.6.2
@@ -2618,8 +2618,8 @@ packages:
   buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
 
-  bufout@0.3.4:
-    resolution: {integrity: sha512-m8iGxYUvWLdQ9CQ9Sjnmr8hJHlpXfRQn2CV3eI5b107MWQqAe/K/pqsCGmczkSy3r7E1HW5u5z86z2aBYbwwxQ==}
+  bufout@1.0.0:
+    resolution: {integrity: sha512-ZCFKJOWLZqZKitcDUTIsJucC9EhOiYl/wb7Fg1TfzlFz1FhjrykZAkn5Gb7JyIsW5ViZjDXL8tr2bXReM/u/XQ==}
 
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
@@ -7367,7 +7367,7 @@ snapshots:
       base64-js: 1.5.1
       ieee754: 1.2.1
 
-  bufout@0.3.4: {}
+  bufout@1.0.0: {}
 
   bytes@3.1.2: {}
 


### PR DESCRIPTION
## Summary

Upgrades `bufout` to v1.0.0, which implements efficient listener management for concurrent child process spawning. This eliminates the need to raise `EventEmitter.defaultMaxListeners` to 100 across the CLI packages.

## Changes

- **Dependency upgrade**: Updated `bufout` from ^0.3.2 to ^1.0.0 in `@react-native-node-api/cli-utils`
- **Removed EventEmitter configuration**: Deleted `EventEmitter.defaultMaxListeners = 100` assignments from:
  - `packages/ferric/src/run.ts`
  - `packages/cmake-rn/src/cli.ts`
  - `packages/host/src/node/cli/program.ts`
- **Removed unused imports**: Cleaned up now-unnecessary `EventEmitter` imports from the above files

## Implementation Details

The new version of `bufout` uses a shared pass-through stream per destination and attaches a single shared `exit`/`SIGINT` listener only while children are running. This keeps the number of listeners constant regardless of concurrent child process count, restoring Node's default listener limit and re-enabling the leak detection warning it provides.

https://claude.ai/code/session_01BAjP89a9VA9EtQsVBxGcto