### PR TITLE
ci: put ccache in front of the Hermes build

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -225,8 +225,9 @@ jobs:
           key: ${{ github.job }}-${{ runner.os }}
           # The action defaults to 500M, which a from-source React Native build
           # fills mid-build: it evicted 88 times in one run, discarding most of
-          # what it had just cached.
-          max-size: 3G
+          # what it had just cached. Raised again to also hold Hermes, which is
+          # by far the largest thing compiled here.
+          max-size: 6G
       - run: rustup target add aarch64-apple-ios-sim x86_64-apple-ios
       - run: pnpm install
       - run: pnpm run bootstrap
@@ -238,12 +239,26 @@ jobs:
       # to it) and so no longer does now that it runs as a compiler launcher.
       # Without this sloppiness Xcode's modules, PCH and index-store flags leave
       # ccache treating almost every compile as uncacheable.
+      #
+      # Hermes is built from source (the Node-API fork), from a CMake build that
+      # React Native drives in a script phase — so C_COMPILER_LAUNCHER, an Xcode
+      # build setting, never reaches it. It is the dominant cost of the build:
+      # 17m15s of an 18m58s build step in run 31691647982. CMake reads
+      # CMAKE_TOOLCHAIN_FILE from the environment, so a toolchain file is enough
+      # to put ccache in front of its compiler without patching React Native.
+      # Only '[RN] [2] Build Hermes' benefits; '[1] Build Hermesc' runs under
+      # `env -i` and cannot see this.
       - name: Tune ccache for Xcode
         run: |
           ccache --set-config sloppiness=clang_index_store,file_stat_matches,include_file_ctime,include_file_mtime,ivfsoverlay,pch_defines,modules,system_headers,time_macros
           ccache --set-config file_clone=true
           ccache --set-config depend_mode=true
           ccache --set-config inode_cache=true
+          cat > "$RUNNER_TEMP/hermes-ccache-toolchain.cmake" <<EOF
+          set(CMAKE_C_COMPILER_LAUNCHER "$(command -v ccache)" CACHE STRING "")
+          set(CMAKE_CXX_COMPILER_LAUNCHER "$(command -v ccache)" CACHE STRING "")
+          EOF
+          echo "CMAKE_TOOLCHAIN_FILE=$RUNNER_TEMP/hermes-ccache-toolchain.cmake" >> $GITHUB_ENV
       # Must precede `pod install`: react-native-test-app embeds the resources
       # declared in app.json when generating the workspace, skipping missing
       # ones, and the app would then expect a Metro dev server at runtime.


### PR DESCRIPTION
Hermes is the iOS build. Everything else is rounding error.

Measured from the job logs of run [31691647982](https://github.com/callstackincubator/react-native-node-api/actions/runs/31691647982):

| Phase | Duration | Share of `Build test app` |
| --- | --- | --- |
| `[RN] [1] Build Hermesc` | 3m40s | 19% |
| `[RN] [2] Build Hermes` | 13m35s | 72% |
| **Hermes total** | **17m15s** | **91%** |
| `Build test app` step | 18m58s | 100% |

It is not hidden concurrency: no `CompileC` or `SwiftCompile` task appears anywhere in the 13m35s `[2] Build Hermes` window — just ninja progress — and all 54 `CompileC` tasks in the entire build land in the final 66 seconds. Hermes serialises the build.

And ccache never saw any of it. `C_COMPILER_LAUNCHER` is an Xcode build setting, whereas Hermes is built by CMake from a script phase, so the two never meet. That job logged 549 ccache calls in total, of which only 68 were cacheable — against 2190 calls / 1082 cacheable on a build that compiles React Native itself.

## Approach

`build-hermes-xcode.sh` hard-codes its CMake flags and offers no hook for extra arguments, but it does not sanitise the environment — and CMake reads `CMAKE_TOOLCHAIN_FILE` from there. So a generated toolchain file setting `CMAKE_C_COMPILER_LAUNCHER` / `CMAKE_CXX_COMPILER_LAUNCHER` is enough to put ccache in front of Hermes' compiler without patching React Native.

Verified locally before pushing: with `CMAKE_TOOLCHAIN_FILE` present only in the environment, CMake applies the toolchain and the launcher reaches the compile rule.

The ccache ceiling also goes from 3G to 6G, since Hermes is far larger than anything cached here so far.

## Known limit

`[RN] [1] Build Hermesc` is out of reach. It runs its CMake under `env -i` with only `PATH` and `SDKROOT`, so no environment-based injection can reach it and it keeps costing its 3m40s. Reaching that one would need a change in React Native itself.

## What this does not do

The bigger prize is not compiling Hermes at all. React Native supports it — `HERMES_ENGINE_TARBALL_PATH` selects `LOCAL_PREBUILT_TARBALL` and the script phases then do not run — but `hermes_source_type()` checks `override_hermes_dir_envvar_defined()` first, and that override comes from this repo's Podfile integration rather than from CI. So consuming a prebuilt Hermes is a change to how the library vendors Hermes, affecting consumers and not just this workflow. Deliberately left for a separate PR.

## Test plan

- [ ] `Test app (iOS)` passes (label-gated on `Apple 🍎`, added)
- [ ] First run seeds the cache — expect no speed-up, and confirm the Hermes compiles now register as *cacheable* in the ccache stats
- [ ] A second run on the same commit should show the `[2] Build Hermes` phase drop sharply

---
_Generated by [Claude Code](https://claude.ai/code/session_01UxzZtpa5Nz3F8ACXzX7Hww)_