### PR TITLE
Stop the host Hermes compiler build from targeting visionOS

### DIFF
--- a/.changeset/prebuilt-hermes-visionos-env.md
+++ b/.changeset/prebuilt-hermes-visionos-env.md
@@ -1,0 +1,13 @@
+---
+"react-native-node-api": patch
+---
+
+Fix `prebuilt-hermes` failing to configure the host Hermes compiler with "Host
+compiler appears to require libatomic, but cannot find it". It exported all
+three deployment targets Hermes' `build-apple-framework.sh` can ask for to every
+command it ran, including the host compiler build. `XROS_DEPLOYMENT_TARGET` is
+also a clang driver variable, so clang targeted visionOS against the macOS
+sysroot, and every API marked unavailable there — `pthread_mutexattr_init`, the
+`fd_set` helpers reached through `unistd.h` — failed to compile. Each platform
+build now gets only the deployment target it needs, and the host compiler build
+gets none.

--- a/.github/workflows/hermes-prebuilt.yml
+++ b/.github/workflows/hermes-prebuilt.yml
@@ -67,6 +67,37 @@ jobs:
         run: |
           path=$(pnpm exec react-native-node-api prebuilt-hermes --no-download)
           echo "path=$path" >> "$GITHUB_OUTPUT"
+      # CMake reports a failed feature check as a bare "not found", with the
+      # compiler's actual complaint only in its configure log. Surface that log
+      # here so a failure is diagnosable without another round trip.
+      - name: Dump CMake configure log
+        if: failure()
+        run: |
+          log=$(find "$PWD" -name CMakeConfigureLog.yaml -path '*build_host_hermesc*' | head -1)
+          if [ -z "$log" ]; then
+            echo "No CMakeConfigureLog.yaml found"
+            find "$PWD" -name 'CMakeError.log' -path '*build_host_hermesc*' -exec cat {} \;
+            exit 0
+          fi
+          echo "::group::Environment seen by CMake"
+          env | sort
+          xcode-select --print-path
+          xcrun --show-sdk-path || true
+          echo "::endgroup::"
+          echo "::group::unistd.h check"
+          grep -n -B 5 -A 45 'unistd\.h' "$log" | head -150
+          echo "::endgroup::"
+          echo "::group::atomics check"
+          grep -n -B 5 -A 60 'HAVE_CXX_ATOMICS_WITHOUT_LIB' "$log" | head -180
+          echo "::endgroup::"
+          cp "$log" "$RUNNER_TEMP/CMakeConfigureLog.yaml"
+      - name: Upload CMake configure log
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: hermesc-cmake-configure-log
+          path: ${{ runner.temp }}/CMakeConfigureLog.yaml
+          if-no-files-found: ignore
       # --latest=false keeps these out of the "latest release" slot, which
       # belongs to the package releases changesets publishes.
       - name: Publish as a release asset

--- a/packages/host/src/node/cli/hermes-prebuilt.ts
+++ b/packages/host/src/node/cli/hermes-prebuilt.ts
@@ -27,13 +27,25 @@ const RELEASES_URL =
 
 export const DEFAULT_PLATFORMS = ["iphoneos", "iphonesimulator"];
 
-// Passed to Hermes' build-apple-framework.sh, which errors out rather than
-// assume one. These match React Native's own podspec declarations.
-const DEPLOYMENT_TARGETS = {
-  IOS_DEPLOYMENT_TARGET: "15.1",
-  MAC_DEPLOYMENT_TARGET: "10.15",
-  XROS_DEPLOYMENT_TARGET: "1.0",
-};
+/**
+ * The deployment target build-apple-framework.sh reads for a platform — it
+ * errors out rather than assume one. These match React Native's own podspec
+ * declarations.
+ *
+ * Only the variable that platform needs is passed. XROS_DEPLOYMENT_TARGET is
+ * also a clang driver variable, so leaking it into a build that isn't for
+ * visionOS makes clang target visionOS against whatever sysroot it was given —
+ * and every API marked unavailable there then fails to compile.
+ */
+function getDeploymentTarget(platform: string): Record<string, string> {
+  if (platform === "macosx") {
+    return { MAC_DEPLOYMENT_TARGET: "10.15" };
+  } else if (platform === "xros" || platform === "xrsimulator") {
+    return { XROS_DEPLOYMENT_TARGET: "1.0" };
+  } else {
+    return { IOS_DEPLOYMENT_TARGET: "15.1" };
+  }
+}
 
 export const BUILD_TYPES = ["debug", "release"] as const;
 export type BuildType = (typeof BUILD_TYPES)[number];
@@ -162,15 +174,19 @@ async function buildArchive({
   // vendored copy: the framework and the app linking it share jsi::Runtime.
   const jsiPath = path.join(reactNativePath, "ReactCommon", "jsi");
 
-  const run = (command: string, args: string[]) =>
+  const run = (
+    command: string,
+    args: string[],
+    extraEnv: Record<string, string> = {},
+  ) =>
     spawn(command, args, {
       cwd: hermesPath,
       outputMode: "inherit",
       // Keeps the build log off stdout, which callers parse for the final path.
       stdout: process.stderr,
       env: {
-        ...DEPLOYMENT_TARGETS,
         ...process.env,
+        ...extraEnv,
         JSI_PATH: jsiPath,
         BUILD_TYPE: buildType === "debug" ? "Debug" : "Release",
         HERMES_OVERRIDE_HERMESC_PATH: importHostCompilersPath,
@@ -202,7 +218,11 @@ async function buildArchive({
   }
 
   for (const platform of platforms) {
-    await run("./utils/build-apple-framework.sh", [platform]);
+    await run(
+      "./utils/build-apple-framework.sh",
+      [platform],
+      getDeploymentTarget(platform),
+    );
   }
 
   const frameworksPath = path.join(


### PR DESCRIPTION
Fixes the `Hermes prebuilt` workflow, which had failed on every run ([1](https://github.com/callstackincubator/react-native-node-api/actions/runs/31713076501), [2](https://github.com/callstackincubator/react-native-node-api/actions/runs/31713349168), [3](https://github.com/callstackincubator/react-native-node-api/actions/runs/31718486130)) with:

```
CMake Error at external/llvh/cmake/modules/CheckAtomic.cmake:53 (message):
  Host compiler appears to require libatomic, but cannot find it.
```

**Verified: [run 31719660147](https://github.com/callstackincubator/react-native-node-api/actions/runs/31719660147) on this branch built Hermes in 26m46s and published the first asset** — [`hermes-5a795c9f8800-rn0.88.0-nightly-20260809-db662caea-debug-iphoneos-iphonesimulator-arm64.tar.gz`](https://github.com/callstackincubator/react-native-node-api/releases/tag/hermes-prebuilt-5a795c9f8800), 118 MB, into the release the first failure had left empty.

## The actual cause

`buildArchive` exported all three deployment targets `build-apple-framework.sh` can ask for to **every** command it ran, including the host compiler configure. `XROS_DEPLOYMENT_TARGET` is not only the name that script reads — it is also a clang driver variable. With it set and no explicit target, clang built for visionOS:

```
clang: warning: using sysroot for 'MacOSX' but targeting 'XR' [-Wincompatible-sysroot]
/…/MacOSX.sdk/usr/include/sys/_types/_fd_def.h:64:18: error:
  '__darwin_check_fd_set_overflow' is unavailable: not available on visionOS
/…/c++/v1/__thread/support/pthread.h:54:14: error:
  'pthread_mutexattr_init' is unavailable: not available on visionOS
```

Every feature check touching an API marked unavailable on visionOS failed, and CMake reports those as a bare `not found`. That is what made this hard to read from the console log: `unistd.h` reported missing while `sys/stat.h` did not, which looks impossible until you see that `unistd.h` reaches `_fd_def.h` through `sys/select.h` and `sys/stat.h` doesn't. `CheckAtomic` was simply the first such check that treats failure as fatal.

Each platform build now gets only the deployment target that platform needs, and the host compiler build gets none. This also explains why React Native's own `[RN] [1] Build Hermesc` never hit it: that runs its CMake under `env -i`, so nothing from the job environment reaches clang.

## How it was found

Two earlier attempts were guesses from console output and both were wrong — first `CMAKE_OSX_ARCHITECTURES` (#442, removed on a hypothesis that turned out not to be the cause; that change is still worth keeping for the archive-naming reasons in its own description), then a suspicion about inherited environment in general, right in shape but not actionable without knowing which variable.

What settled it was the failure-only diagnostic added here: it dumps CMake's `CMakeConfigureLog.yaml`, where the compiler's real complaint lives, plus the job environment, `xcode-select -p` and the SDK path, and uploads the full log as an artifact. Those steps are kept — this configure was misdiagnosed twice from the console log alone, and they turn the next occurrence into one round trip.

A useful control along the way: the identical configure succeeds on Linux against the same pinned Hermes (every header found, `HAVE_CXX_ATOMICS_WITHOUT_LIB - Success`), which ruled out the Hermes source, the pin and the CMake arguments.

## Test plan

- [x] `Hermes prebuilt` dispatched on this branch gets past the host compiler and publishes an asset
- [x] The published asset name round-trips: GitHub stored it byte-identical to what `--print name` produces, and the URL `--print url` composes serves a valid gzip
- [ ] #441 is restacked on this branch — its `Test app (iOS)` should now download the asset rather than build