### PR TITLE
Skip the Hermes build when the archive is already published

### DIFF
--- a/.github/workflows/hermes-prebuilt.yml
+++ b/.github/workflows/hermes-prebuilt.yml
@@ -12,6 +12,11 @@ env:
 
 on:
   workflow_dispatch:
+    inputs:
+      force:
+        description: Rebuild and re-upload even when the archive is already published
+        type: boolean
+        default: false
   push:
     branches:
       - main
@@ -54,7 +59,32 @@ jobs:
           tag=$(pnpm exec react-native-node-api prebuilt-hermes --print tag)
           echo "archive=$archive" >> "$GITHUB_OUTPUT"
           echo "tag=$tag" >> "$GITHUB_OUTPUT"
+      # The paths filter above fires on any edit to these files, not just a
+      # bumped pin — and the archive name covers every input that changes its
+      # contents, so an asset already published under that name is exactly what
+      # this run would spend half an hour rebuilding. The Actions cache is not
+      # enough on its own: it is scoped to the branch that wrote it, and evicts
+      # after 7 days or under the repository's 10 GB cap.
+      - name: Look for an already-published archive
+        id: published
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.hermes.outputs.tag }}
+          ARCHIVE: ${{ steps.hermes.outputs.archive }}
+          FORCE: ${{ inputs.force }}
+        run: |
+          if [ "$FORCE" = "true" ]; then
+            echo "::notice::Forced: rebuilding $ARCHIVE regardless of what is published"
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          elif gh release view "$TAG" --repo "$GITHUB_REPOSITORY" --json assets \
+               --jq '.assets[].name' 2>/dev/null | grep -qxF "$ARCHIVE"; then
+            echo "::notice::$ARCHIVE is already published under $TAG — nothing to build"
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
       - name: Cache prebuilt Hermes
+        if: steps.published.outputs.exists != 'true'
         uses: actions/cache@v6
         with:
           path: ~/Library/Caches/react-native-node-api/hermes-prebuilt
@@ -63,6 +93,7 @@ jobs:
       # it is about to publish.
       - name: Build prebuilt Hermes
         id: build
+        if: steps.published.outputs.exists != 'true'
         working-directory: apps/test-app
         run: |
           path=$(pnpm exec react-native-node-api prebuilt-hermes --no-download)
@@ -71,7 +102,7 @@ jobs:
       # compiler's actual complaint only in its configure log. Surface that log
       # here so a failure is diagnosable without another round trip.
       - name: Dump CMake configure log
-        if: failure()
+        if: failure() && steps.published.outputs.exists != 'true'
         run: |
           log=$(find "$PWD" -name CMakeConfigureLog.yaml -path '*build_host_hermesc*' | head -1)
           if [ -z "$log" ]; then
@@ -92,7 +123,7 @@ jobs:
           echo "::endgroup::"
           cp "$log" "$RUNNER_TEMP/CMakeConfigureLog.yaml"
       - name: Upload CMake configure log
-        if: failure()
+        if: failure() && steps.published.outputs.exists != 'true'
         uses: actions/upload-artifact@v7
         with:
           name: hermesc-cmake-configure-log
@@ -101,6 +132,7 @@ jobs:
       # --latest=false keeps these out of the "latest release" slot, which
       # belongs to the package releases changesets publishes.
       - name: Publish as a release asset
+        if: steps.published.outputs.exists != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ steps.hermes.outputs.tag }}


### PR DESCRIPTION
Merging #443 kicked off [run 31724154546](https://github.com/callstackincubator/react-native-node-api/actions/runs/31724154546), which set about rebuilding — for half an hour — the archive that had been published 25 minutes earlier, to then re-upload 118 MB byte-for-byte equivalent to what was already there. I cancelled it.

## What did and didn't guard this

**The `paths:` filter works.** The workflow does not fire on every merge to `next` — only on edits to `hermes.ts`, `hermes-prebuilt.ts` or the workflow itself. But that still means any unrelated edit to those files (a comment, a refactor, a new CLI flag) pays for a full rebuild, and #443 was exactly that.

**The Actions cache does not cover it**, for two reasons worth writing down:

- It is scoped to the branch that wrote it. The successful build ran on #443's branch, so the cache it saved was never visible to `next` — and disappeared with the branch.
- Even on the default branch it evicts after 7 days idle, or under the repository's 10 GB cap, which the `test-ios` (3 GB) and other ccache entries already compete for.

**`--no-download` deliberately bypassed the one authoritative signal** — the published asset itself. That flag exists so a forced rebuild doesn't round-trip the asset it is about to replace, which is still right; it just needed a decision made before it.

## The change

The archive name already covers every input that changes its contents — pinned commit, React Native version, build type, platforms, host architecture. So an asset published under that name *is* the archive this run would produce. A new step looks it up with `gh release view --json assets` and, when it is there, skips the cache restore, the build and the upload.

`workflow_dispatch` gains a `force` input for deliberate rebuilds — a corrupted upload, or a toolchain change that alters the output without changing the name.

Cost when the asset exists: checkout, install, build, two `--print` calls and one API lookup. About a minute, versus thirty.

## Known gap, not addressed here

A React Native bump changes the archive name but touches none of the paths in the filter, so no asset gets published for the new version until someone dispatches manually — CI and consumers fall back to building locally, correctly but slowly. Adding `pnpm-lock.yaml` to `paths:` would close it, and with this gate in place the cost is a one-minute no-op run per dependency bump. Left out because it widens the trigger noticeably; say the word and it is a one-line follow-up.

## Test plan

- [ ] Dispatched on this branch: `Look for an already-published archive` reports `exists=true`, the build and publish steps skip, and the run finishes in about a minute
- [ ] A dispatch with `force: true` still rebuilds

---
_Generated by [Claude Code](https://claude.ai/code/session_01UkNbgdyuKgHaFwT27RahGH)_