### PR TITLE
Add a fixture registering via the deprecated `napi_module_register`

### DIFF
--- a/packages/node-addon-examples/src/index.ts
+++ b/packages/node-addon-examples/src/index.ts
@@ -86,6 +86,8 @@ export const suites: Record<
       require("../tests/buffers/addon.js");
     },
     async: () => require("../tests/async/addon.js") as () => Promise<void>,
+    "module-register": () =>
+      require("../tests/module-register/addon.js") as () => void,
     "threadsafe-function": () =>
       require("../tests/threadsafe-function/addon.js") as () => Promise<void>,
   },

--- a/packages/node-addon-examples/tests/module-register/CMakeLists.txt
+++ b/packages/node-addon-examples/tests/module-register/CMakeLists.txt
@@ -1,0 +1,28 @@
+cmake_minimum_required(VERSION 3.15...3.31)
+project(module-register-test)
+
+find_package(weak-node-api REQUIRED CONFIG)
+
+add_library(module-register-test-addon SHARED addon.c)
+
+option(BUILD_APPLE_FRAMEWORK "Wrap addon in an Apple framework" ON)
+
+if(APPLE AND BUILD_APPLE_FRAMEWORK)
+  set_target_properties(module-register-test-addon PROPERTIES
+    FRAMEWORK TRUE
+    MACOSX_FRAMEWORK_IDENTIFIER module-register-test.addon
+    MACOSX_FRAMEWORK_SHORT_VERSION_STRING 1.0
+    MACOSX_FRAMEWORK_BUNDLE_VERSION 1.0
+    XCODE_ATTRIBUTE_SKIP_INSTALL NO
+    OUTPUT_NAME addon
+   )
+else()
+  set_target_properties(module-register-test-addon PROPERTIES
+    PREFIX ""
+    SUFFIX .node
+    OUTPUT_NAME addon
+   )
+endif()
+
+target_link_libraries(module-register-test-addon PRIVATE weak-node-api)
+target_compile_features(module-register-test-addon PRIVATE cxx_std_17)

--- a/packages/node-addon-examples/tests/module-register/addon.c
+++ b/packages/node-addon-examples/tests/module-register/addon.c
@@ -1,0 +1,42 @@
+#include <node_api.h>
+
+// This addon registers itself the deprecated way — a napi_module_register call
+// made while the library loads — and deliberately exports no
+// napi_register_module_v1 symbol, so a host that only looks for that symbol
+// cannot load it.
+//
+// The constructor is hand-rolled because node_api.h no longer offers a macro
+// that emits one: NAPI_MODULE_X is now an alias of the symbol-based
+// NAPI_MODULE.
+
+static napi_value Registration(napi_env env, napi_callback_info info) {
+  (void)info;
+  napi_value result;
+  if (napi_create_string_utf8(env, "napi_module_register", NAPI_AUTO_LENGTH,
+                              &result) != napi_ok) {
+    return NULL;
+  }
+  return result;
+}
+
+static napi_value Init(napi_env env, napi_value exports) {
+  napi_property_descriptor properties[] = {
+      {"registration", NULL, Registration, NULL, NULL, NULL, napi_default,
+       NULL},
+  };
+  if (napi_define_properties(env, exports,
+                             sizeof(properties) / sizeof(properties[0]),
+                             properties) != napi_ok) {
+    return NULL;
+  }
+  return exports;
+}
+
+static napi_module addon_module = {
+    NAPI_MODULE_VERSION, 0,    __FILE__, Init, "module-register-test",
+    NULL,                {0},
+};
+
+__attribute__((constructor)) static void RegisterAddon(void) {
+  napi_module_register(&addon_module);
+}

--- a/packages/node-addon-examples/tests/module-register/addon.js
+++ b/packages/node-addon-examples/tests/module-register/addon.js
@@ -1,0 +1,6 @@
+const assert = require("assert");
+const addon = require("bindings")("addon.node");
+
+module.exports = () => {
+  assert.strictEqual(addon.registration(), "napi_module_register");
+};

--- a/packages/node-addon-examples/tests/module-register/addon.js
+++ b/packages/node-addon-examples/tests/module-register/addon.js
@@ -1,5 +1,7 @@
 const assert = require("assert");
-const addon = require("bindings")("addon.node");
+// cmake-rn emits to {targetSourceDir}/build/{configuration}, and this package's
+// build script pins the configuration.
+const addon = require("./build/RelWithDebInfo/addon.node");
 
 module.exports = () => {
   assert.strictEqual(addon.registration(), "napi_module_register");

--- a/packages/node-addon-examples/tests/module-register/binding.gyp
+++ b/packages/node-addon-examples/tests/module-register/binding.gyp
@@ -1,0 +1,8 @@
+{
+  "targets": [
+    {
+      "target_name": "addon",
+      "sources": [ "addon.c" ]
+    }
+  ]
+}

--- a/packages/node-addon-examples/tests/module-register/binding.gyp
+++ b/packages/node-addon-examples/tests/module-register/binding.gyp
@@ -1,8 +1,0 @@
-{
-  "targets": [
-    {
-      "target_name": "addon",
-      "sources": [ "addon.c" ]
-    }
-  ]
-}

--- a/packages/node-addon-examples/tests/module-register/package.json
+++ b/packages/node-addon-examples/tests/module-register/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "module-register-test",
+  "version": "0.0.0",
+  "description": "Tests of the deprecated napi_module_register registration",
+  "main": "addon.js",
+  "private": true,
+  "dependencies": {
+    "bindings": "~1.5.0"
+  },
+  "scripts": {
+    "test": "node addon.js"
+  },
+  "gypfile": true
+}

--- a/packages/node-addon-examples/tests/module-register/package.json
+++ b/packages/node-addon-examples/tests/module-register/package.json
@@ -3,8 +3,5 @@
   "version": "0.0.0",
   "description": "Tests of the deprecated napi_module_register registration",
   "main": "addon.js",
-  "private": true,
-  "dependencies": {
-    "bindings": "~1.5.0"
-  }
+  "private": true
 }

--- a/packages/node-addon-examples/tests/module-register/package.json
+++ b/packages/node-addon-examples/tests/module-register/package.json
@@ -6,9 +6,5 @@
   "private": true,
   "dependencies": {
     "bindings": "~1.5.0"
-  },
-  "scripts": {
-    "test": "node addon.js"
-  },
-  "gypfile": true
+  }
 }


### PR DESCRIPTION
Follow-up to #445, which made the host load addons that register themselves by calling `napi_module_register` while their library loads. Nothing in the repo exercised that path — every other addon here exports `napi_register_module_v1`, which the loader finds first, so the fallback was never reached.

`tests/module-register` exports no `napi_register_module_v1` symbol, so it only loads if the fallback works. Failure mode is a hard one: `requireNodeAddon` throws "no `napi_register_module_v1` export and no registered `napi_module`", and the test fails.

The constructor is hand-rolled:

```c
__attribute__((constructor)) static void RegisterAddon(void) {
  napi_module_register(&addon_module);
}
```

because `node_api.h` no longer ships a macro that emits one — `NAPI_MODULE_X`, the historical spelling, is now an alias of the symbol-based `NAPI_MODULE`. #104 solved this by vendoring a 269-line `node_api_deprecated.h`; four lines seemed better.

Closes #3.

## Leaner than its siblings

The fixture has no `binding.gyp`, no `"gypfile": true`, and no `bindings` dependency.

Nothing builds it from gyp — `cmake-rn` drives the CMake project directly — and the reason the other fixtures carry a gyp file (staying close to the upstream sources they were derived from) does not apply to an addon written here. `CMakeLists.txt` is therefore hand-maintained; `gyp-to-cmake` skips the directory, and `generate-root-project` still picks it up, since it looks for CMake projects rather than gyp files.

`bindings` earns its place when an addon has to be found across the several output directories `node-gyp` might have used. This one is emitted to a single known location, so `addon.js` does a plain `require("./build/RelWithDebInfo/addon.node")` — matching what `ferric-example` already does — which has the side benefit of exercising the Babel plugin's ordinary require path rather than its `bindings` special case.

The `"test": "node addon.js"` script went too: without a `node-gyp` build there is no host-loadable `.node` for it to require, so it could only ever have failed. Happy to put it back if you'd rather keep the shape uniform.

## Verification

- Built the addon standalone and confirmed with `nm -D` that it exports neither `napi_register_module_v1` nor `node_api_module_get_api_version_v1` — i.e. it really does force the fallback.
- Loaded it into Node.js 24 via `process.dlopen` and ran the assertion, so the fixture is well-formed independently of our host.
- Ran the Babel plugin over `addon.js` against a directory laid out like a completed build, and confirmed it rewrites to `require("react-native-node-api").requireNodeAddon("module-register-test--addon")`.
- `generate-root-project` lists `tests/module-register` among its sub-projects after the gyp file was removed.
- `tsc --build`, `eslint`, `prettier --check` clean; `pnpm install` leaves the lockfile untouched.

The fixture itself runs on device, so this needs the iOS and Android jobs — hence the labels.

## Notes

- No changeset: `@react-native-node-api/node-addon-examples` is private and no published package changes behavior.
- I dropped a `node_api_get_module_file_name` assertion I had initially added here. Hermes sets `env->moduleFileName_` unconditionally in `hermes_napi_load_module`, so it holds on our host, but Node.js only populates it when loading through `require` — via `process.dlopen` it returns `""` for symbol-based and deprecated registration alike. An assertion that only holds in one of the two runtimes a fixture can run in seemed worse than no assertion. That claim from #445 stays unverified.
- Unrelated to this PR but worth recording: Hermes never clears `lastRegisteredModule` after a load. Node clears its equivalent (nodejs/node@a60056d) precisely so a failed or symbol-less load cannot pick up a stale registration from an earlier addon. Two deprecated addons in one app, or one that fails to load after another registered, can therefore resolve to the wrong init function. Worth folding into the upstream issue drafted in #4.
