### PR TITLE
fix: verify prebuild Info.plist and prove the Babel plugin's .js/.node precedence (#424)

### DIFF
--- a/.changeset/loud-pandas-jump.md
+++ b/.changeset/loud-pandas-jump.md
@@ -1,0 +1,11 @@
+---
+"react-native-node-api": patch
+---
+
+Fixed the Babel plugin rewriting `require('./foo')` to load a Node-API addon
+even when a same-named `foo.js`/`.cjs`/`.mjs`/`.json` file exists alongside it
+— that source file is what Node's own `require()` resolves to, so the addon
+was never reachable at runtime through that specific call, only through an
+explicit `require('./foo.node')`.
+
+Also exported `escapeBundleIdentifier` from the package's `node` entrypoint.

--- a/packages/host/src/node/babel-plugin/plugin.test.ts
+++ b/packages/host/src/node/babel-plugin/plugin.test.ts
@@ -129,8 +129,9 @@ describe("plugin", () => {
     itTransforms("and does not touch required JS files", {
       files: {
         "package.json": `{ "name": "my-package" }`,
-        // TODO: Add a ./my-addon.node to make this test complete
         "my-addon.js": "// Some JS file",
+        "my-addon.apple.node/my-addon.node":
+          "// This is supposed to be a binary file",
         "index.js": `
           const addon = require('./my-addon');
           console.log(addon);

--- a/packages/host/src/node/index.ts
+++ b/packages/host/src/node/index.ts
@@ -20,6 +20,7 @@ export {
   createXCframework,
   createUniversalAppleLibrary,
   determineXCFrameworkFilename,
+  escapeBundleIdentifier,
 } from "./prebuilds/apple.js";
 
 export {

--- a/packages/host/src/node/path-utils.ts
+++ b/packages/host/src/node/path-utils.ts
@@ -59,6 +59,9 @@ export type NamingStrategy = {
 // Cache mapping package directory to package name across calls
 const packageNameCache = new Map<string, string>();
 
+// Extensions Node's own require() resolves before ever trying `.node`.
+const COLLIDING_SOURCE_EXTENSIONS = [".js", ".cjs", ".mjs", ".json"];
+
 /**
  * @param modulePath  Batch-scans the path to the module to check (must be extensionless or end in .node)
  * @returns True if a platform specific prebuild exists for the module path, warns on unreadable modules.
@@ -66,6 +69,15 @@ const packageNameCache = new Map<string, string>();
  * TODO: Consider checking for a specific platform extension.
  */
 export function isNodeApiModule(modulePath: string): boolean {
+  if (
+    !modulePath.endsWith(".node") &&
+    COLLIDING_SOURCE_EXTENSIONS.some((extension) =>
+      fs.existsSync(modulePath + extension),
+    )
+  ) {
+    // An explicit require('./foo.node') has no such ambiguity to defer to.
+    return false;
+  }
   {
     // HACK: Take a shortcut (if applicable): existing `.node` files are addons
     try {

--- a/packages/node-addon-examples/package.json
+++ b/packages/node-addon-examples/package.json
@@ -37,7 +37,9 @@
     "weak-node-api": "workspace:*"
   },
   "dependencies": {
+    "@expo/plist": "0.4.7",
     "assert": "^2.1.0",
-    "react-native-node-api": "workspace:*"
+    "react-native-node-api": "workspace:*",
+    "zod": "^4.1.11"
   }
 }

--- a/packages/node-addon-examples/scripts/verify-prebuilds.mts
+++ b/packages/node-addon-examples/scripts/verify-prebuilds.mts
@@ -2,7 +2,21 @@ import fs from "node:fs";
 import assert from "node:assert/strict";
 import path from "node:path";
 
+import plistModule from "@expo/plist";
+import { escapeBundleIdentifier } from "react-native-node-api";
+import { z } from "zod";
+
 import { DIRS } from "./cmake-projects.mjs";
+
+// @expo/plist is CJS with an `export default`; under Node's ESM/CJS interop
+// the default import binds to the whole `module.exports`, which nests the
+// real API one `.default` deeper.
+const plist = plistModule.default;
+
+const FrameworkInfoPlistSchema = z.object({
+  CFBundleExecutable: z.string(),
+  CFBundleIdentifier: z.string(),
+});
 
 const EXPECTED_ANDROID_ARCHS = ["armeabi-v7a", "arm64-v8a", "x86_64", "x86"];
 
@@ -37,6 +51,27 @@ async function verifyAndroidPrebuild(dirent: fs.Dirent) {
   }
 }
 
+async function verifyFrameworkInfoPlist(
+  infoPlistPath: string,
+  libraryName: string,
+) {
+  const contents = await fs.promises.readFile(infoPlistPath, "utf8");
+  const parsed = FrameworkInfoPlistSchema.parse(plist.parse(contents));
+  assert.equal(
+    parsed.CFBundleExecutable,
+    libraryName,
+    `Unexpected CFBundleExecutable in ${infoPlistPath}`,
+  );
+  assert.equal(
+    parsed.CFBundleIdentifier,
+    // Mirrors the default writeFrameworkInfoPlist derives in
+    // packages/host/src/node/prebuilds/apple.ts, since none of the
+    // examples pass --apple-bundle-identifier.
+    escapeBundleIdentifier(`com.callstackincubator.node-api.${libraryName}`),
+    `Unexpected CFBundleIdentifier in ${infoPlistPath}`,
+  );
+}
+
 async function verifyApplePrebuild(dirent: fs.Dirent) {
   console.log("Verifying Apple prebuild", dirent.name, "in", dirent.parentPath);
   for (const arch of EXPECTED_XCFRAMEWORK_PLATFORMS) {
@@ -65,8 +100,11 @@ async function verifyApplePrebuild(dirent: fs.Dirent) {
             "Expected only directory and files in framework",
           );
           if (file.name === "Info.plist") {
-            // TODO: Verify the contents of the Info.plist file
-            continue;
+            const libraryName = path.basename(frameworkDir, ".framework");
+            await verifyFrameworkInfoPlist(
+              path.join(frameworkDir, file.name),
+              libraryName,
+            );
           } else {
             assert(
               !file.name.endsWith(".node"),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -274,12 +274,18 @@ importers:
 
   packages/node-addon-examples:
     dependencies:
+      '@expo/plist':
+        specifier: 0.4.7
+        version: 0.4.7
       assert:
         specifier: ^2.1.0
         version: 2.1.0
       react-native-node-api:
         specifier: workspace:*
         version: link:../host
+      zod:
+        specifier: ^4.1.11
+        version: 4.4.3
     devDependencies:
       cmake-rn:
         specifier: workspace:*
@@ -4095,14 +4101,6 @@ packages:
     resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
     engines: {node: '>=12'}
 
-  pify@4.0.1:
-    resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
-    engines: {node: '>=6'}
-
-  pirates@4.0.7:
-    resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
-    engines: {node: '>= 6'}
-
   pkg-dir@8.0.0:
     resolution: {integrity: sha512-4peoBq4Wks0riS0z8741NVv+/8IiTvqnZAr8QGgtdifrtpdXbNw/FxRS1l6NFqm4EMzuS0EDqNNx4XGaz8cuyQ==}
     engines: {node: '>=18'}
@@ -4411,10 +4409,6 @@ packages:
 
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
-
-  slash@3.0.0:
-    resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
-    engines: {node: '>=8'}
 
   slice-ansi@2.1.0:
     resolution: {integrity: sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==}
@@ -6790,7 +6784,9 @@ snapshots:
       metro-runtime: 0.87.0
     transitivePeerDependencies:
       - '@babel/core'
+      - bufferutil
       - supports-color
+      - utf-8-validate
 
   '@react-native/normalize-colors@0.88.0-nightly-20260809-db662caea': {}
 
@@ -8994,10 +8990,6 @@ snapshots:
 
   picomatch@4.0.5: {}
 
-  pify@4.0.1: {}
-
-  pirates@4.0.7: {}
-
   pkg-dir@8.0.0:
     dependencies:
       find-up-simple: 1.0.1
@@ -9377,8 +9369,6 @@ snapshots:
   signal-exit@4.1.0: {}
 
   sisteransi@1.0.5: {}
-
-  slash@3.0.0: {}
 
   slice-ansi@2.1.0:
     dependencies:


### PR DESCRIPTION
Closes #424.

## `verify-prebuilds` now reads the `Info.plist` it finds

`verifyApplePrebuild` used to `continue` past `Info.plist` without reading it. It now parses it with `@expo/plist` (already a dependency elsewhere in the repo) and asserts, via a small `verifyFrameworkInfoPlist` helper:

- `CFBundleExecutable` matches the framework's library name (the `.framework` directory's basename)
- `CFBundleIdentifier` matches `escapeBundleIdentifier("com.callstackincubator.node-api." + libraryName)` — the default `writeFrameworkInfoPlist` (`packages/host/src/node/prebuilds/apple.ts`) writes when no `--apple-bundle-identifier` is passed, which is how `node-addon-examples` builds

`escapeBundleIdentifier` is now exported from `react-native-node-api`'s public `node` entrypoint so the verify script (a consumer of the package, like any addon author) can import it rather than re-deriving the escaping rule. The parsed plist is validated with a `zod` schema rather than accessed as `any`, matching how the rest of the codebase validates untrusted structured data.

Note on the `@expo/plist` import: it's a CJS package with an `export default`. `verify-prebuilds.mts` is genuine ESM (`.mts`), so Node's real CJS/ESM interop binds the default import to the whole `module.exports`, nesting the actual `{ parse, build }` API one `.default` deeper — confirmed empirically against Node's own module loader, and against `tsx` (the runner this script actually uses), not just against `tsc`.

## The Babel plugin test now proves its own claim — and that found a real bug

"and does not touch required JS files" asserted the plugin leaves `require('./my-addon')` alone, but the fixture had no `my-addon.*.node` for the plugin to have found in the first place — the assertion passed for the wrong reason. Adding a sibling `my-addon.apple.node/my-addon.node` (as the `TODO` asked, following the same fixture pattern used by every other test in the file) makes the test exercise real precedence between a `.js` file and a same-named addon, and it failed: `isNodeApiModule` didn't check whether a same-named `.js`/`.cjs`/`.mjs`/`.json` file would already satisfy `require()` before considering `.node` prebuilds, so the plugin rewrote a call that Node's own resolution would never route to the addon.

Fixed `isNodeApiModule` to defer to a colliding source file when the module path has no explicit `.node` extension, matching Node's own resolution order (`.js`/`.json` before `.node`). Explicit `require('./my-addon.node')` calls are untouched by this check, since there's no resolution ambiguity to defer to.

## Verification

- `pnpm run build`, `pnpm run lint`, `pnpm run prettier:check` all clean
- `packages/host`'s full test suite: only the same 4 permission-based tests fail, and they fail identically on `next` before this change (this sandbox runs as root, so permission-removal tests can't produce the expected effect) — no new failures
- Manually exercised the new `verifyFrameworkInfoPlist` logic (both match and mismatch-detection paths) against a real `Info.plist` written by `createAppleFramework`, run both directly with `node` and through `tsx` (the actual runner `verify-prebuilds.mts` uses) — `install_name_tool` isn't available on Linux, so the check reads the file right after it's written, before that step
- Added a changeset for `react-native-node-api` (the `isNodeApiModule` fix + new export); none needed for `node-addon-examples`, which is private

cc @kraenhansen for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Q1k6UQJPPaqKEKmnsRUatt)_