### PR TITLE
Fix .js/.node precedence in isNodeApiModule; dedupe Info.plist checks (builds on #426)

### DIFF
--- a/.changeset/calm-bears-resolve.md
+++ b/.changeset/calm-bears-resolve.md
@@ -2,4 +2,4 @@
 "react-native-node-api": patch
 ---
 
-Preserve Node.js module resolution precedence when a JavaScript file and native addon share a basename.
+Preserve Node.js module resolution precedence when a JavaScript file and native addon share a basename: `require('./foo')` no longer gets rewritten to load a Node-API addon when a same-named `foo.js`/`.cjs`/`.mjs`/`.json` file exists alongside it, since that source file is what `require()` actually resolves to. An explicit `require('./foo.node')` is unaffected.

--- a/.changeset/calm-bears-resolve.md
+++ b/.changeset/calm-bears-resolve.md
@@ -1,0 +1,5 @@
+---
+"react-native-node-api": patch
+---
+
+Preserve Node.js module resolution precedence when a JavaScript file and native addon share a basename.

--- a/packages/host/src/node/babel-plugin/plugin.test.ts
+++ b/packages/host/src/node/babel-plugin/plugin.test.ts
@@ -129,7 +129,7 @@ describe("plugin", () => {
     itTransforms("and does not touch required JS files", {
       files: {
         "package.json": `{ "name": "my-package" }`,
-        // TODO: Add a ./my-addon.node to make this test complete
+        "my-addon.node": "// This is supposed to be a binary file",
         "my-addon.js": "// Some JS file",
         "index.js": `
           const addon = require('./my-addon');

--- a/packages/host/src/node/babel-plugin/plugin.ts
+++ b/packages/host/src/node/babel-plugin/plugin.ts
@@ -1,5 +1,4 @@
 import assert from "node:assert/strict";
-import { createRequire } from "node:module";
 import path from "node:path";
 
 import type { PluginObj, NodePath } from "@babel/core";
@@ -102,7 +101,6 @@ export function plugin(): PluginObj {
             }
           } else if (
             !path.isAbsolute(id) &&
-            !resolvesToNonNodeModule(id, this.filename) &&
             isNodeApiModule(path.join(from, id))
           ) {
             const relativePath = path.join(from, id);
@@ -115,12 +113,4 @@ export function plugin(): PluginObj {
       },
     },
   };
-}
-
-function resolvesToNonNodeModule(id: string, filename: string): boolean {
-  try {
-    return !createRequire(filename).resolve(id).endsWith(".node");
-  } catch {
-    return false;
-  }
 }

--- a/packages/host/src/node/babel-plugin/plugin.ts
+++ b/packages/host/src/node/babel-plugin/plugin.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { createRequire } from "node:module";
 import path from "node:path";
 
 import type { PluginObj, NodePath } from "@babel/core";
@@ -101,6 +102,7 @@ export function plugin(): PluginObj {
             }
           } else if (
             !path.isAbsolute(id) &&
+            !resolvesToNonNodeModule(id, this.filename) &&
             isNodeApiModule(path.join(from, id))
           ) {
             const relativePath = path.join(from, id);
@@ -113,4 +115,12 @@ export function plugin(): PluginObj {
       },
     },
   };
+}
+
+function resolvesToNonNodeModule(id: string, filename: string): boolean {
+  try {
+    return !createRequire(filename).resolve(id).endsWith(".node");
+  } catch {
+    return false;
+  }
 }

--- a/packages/host/src/node/index.ts
+++ b/packages/host/src/node/index.ts
@@ -20,6 +20,7 @@ export {
   createXCframework,
   createUniversalAppleLibrary,
   determineXCFrameworkFilename,
+  escapeBundleIdentifier,
 } from "./prebuilds/apple.js";
 
 export {

--- a/packages/host/src/node/path-utils.ts
+++ b/packages/host/src/node/path-utils.ts
@@ -59,6 +59,9 @@ export type NamingStrategy = {
 // Cache mapping package directory to package name across calls
 const packageNameCache = new Map<string, string>();
 
+// Extensions Node's own require() resolves before ever trying `.node`.
+const COLLIDING_SOURCE_EXTENSIONS = [".js", ".cjs", ".mjs", ".json"];
+
 /**
  * @param modulePath  Batch-scans the path to the module to check (must be extensionless or end in .node)
  * @returns True if a platform specific prebuild exists for the module path, warns on unreadable modules.
@@ -66,6 +69,15 @@ const packageNameCache = new Map<string, string>();
  * TODO: Consider checking for a specific platform extension.
  */
 export function isNodeApiModule(modulePath: string): boolean {
+  if (
+    !modulePath.endsWith(".node") &&
+    COLLIDING_SOURCE_EXTENSIONS.some((extension) =>
+      fs.existsSync(modulePath + extension),
+    )
+  ) {
+    // An explicit require('./foo.node') has no such ambiguity to defer to.
+    return false;
+  }
   {
     // HACK: Take a shortcut (if applicable): existing `.node` files are addons
     try {

--- a/packages/node-addon-examples/package.json
+++ b/packages/node-addon-examples/package.json
@@ -38,6 +38,7 @@
   },
   "dependencies": {
     "assert": "^2.1.0",
-    "react-native-node-api": "workspace:*"
+    "react-native-node-api": "workspace:*",
+    "zod": "^4.1.11"
   }
 }

--- a/packages/node-addon-examples/package.json
+++ b/packages/node-addon-examples/package.json
@@ -29,6 +29,7 @@
     "bootstrap": "node --run copy-and-build"
   },
   "devDependencies": {
+    "@expo/plist": "0.4.7",
     "cmake-rn": "workspace:*",
     "node-addon-examples": "github:nodejs/node-addon-examples#4b7dd86a85644610e6de80154df9acac9329b509",
     "gyp-to-cmake": "workspace:*",

--- a/packages/node-addon-examples/scripts/verify-prebuilds.mts
+++ b/packages/node-addon-examples/scripts/verify-prebuilds.mts
@@ -3,8 +3,20 @@ import assert from "node:assert/strict";
 import path from "node:path";
 
 import plistModule from "@expo/plist";
+import { escapeBundleIdentifier } from "react-native-node-api";
+import { z } from "zod";
 
 import { EXAMPLES_DIR } from "./cmake-projects.mjs";
+
+// @expo/plist is CJS with an `export default`; under this genuine ESM
+// (.mts) module's interop, the default import binds to the whole
+// `module.exports`, nesting the real API one `.default` deeper.
+const plist = plistModule.default;
+
+const FrameworkInfoPlistSchema = z.object({
+  CFBundleExecutable: z.string(),
+  CFBundleIdentifier: z.string(),
+});
 
 const EXPECTED_ANDROID_ARCHS = ["armeabi-v7a", "arm64-v8a", "x86_64", "x86"];
 
@@ -39,6 +51,27 @@ async function verifyAndroidPrebuild(dirent: fs.Dirent) {
   }
 }
 
+async function verifyFrameworkInfoPlist(
+  infoPlistPath: string,
+  libraryName: string,
+) {
+  const contents = await fs.promises.readFile(infoPlistPath, "utf8");
+  const parsed = FrameworkInfoPlistSchema.parse(plist.parse(contents));
+  assert.equal(
+    parsed.CFBundleExecutable,
+    libraryName,
+    `Unexpected CFBundleExecutable in ${infoPlistPath}`,
+  );
+  assert.equal(
+    parsed.CFBundleIdentifier,
+    // Mirrors the default writeFrameworkInfoPlist derives in
+    // packages/host/src/node/prebuilds/apple.ts, since none of the
+    // examples pass --apple-bundle-identifier.
+    escapeBundleIdentifier(`com.callstackincubator.node-api.${libraryName}`),
+    `Unexpected CFBundleIdentifier in ${infoPlistPath}`,
+  );
+}
+
 async function verifyApplePrebuild(dirent: fs.Dirent) {
   console.log("Verifying Apple prebuild", dirent.name, "in", dirent.parentPath);
   for (const arch of EXPECTED_XCFRAMEWORK_PLATFORMS) {
@@ -68,27 +101,10 @@ async function verifyApplePrebuild(dirent: fs.Dirent) {
           );
           if (file.name === "Info.plist") {
             const libraryName = path.basename(frameworkDir, ".framework");
-            const infoPlist: unknown = plistModule.default.parse(
-              await fs.promises.readFile(
-                path.join(frameworkDir, file.name),
-                "utf8",
-              ),
+            await verifyFrameworkInfoPlist(
+              path.join(frameworkDir, file.name),
+              libraryName,
             );
-            assert(
-              typeof infoPlist === "object" && infoPlist !== null,
-              "Expected Info.plist to contain a dictionary",
-            );
-            assert("CFBundleExecutable" in infoPlist);
-            assert("CFBundleIdentifier" in infoPlist);
-            assert.equal(infoPlist.CFBundleExecutable, libraryName);
-            assert.equal(
-              infoPlist.CFBundleIdentifier,
-              `com.callstackincubator.node-api.${libraryName}`.replace(
-                /[^A-Za-z0-9-.]/g,
-                "-",
-              ),
-            );
-            continue;
           } else {
             assert(
               !file.name.endsWith(".node"),

--- a/packages/node-addon-examples/scripts/verify-prebuilds.mts
+++ b/packages/node-addon-examples/scripts/verify-prebuilds.mts
@@ -2,6 +2,8 @@ import fs from "node:fs";
 import assert from "node:assert/strict";
 import path from "node:path";
 
+import plistModule from "@expo/plist";
+
 import { EXAMPLES_DIR } from "./cmake-projects.mjs";
 
 const EXPECTED_ANDROID_ARCHS = ["armeabi-v7a", "arm64-v8a", "x86_64", "x86"];
@@ -65,7 +67,27 @@ async function verifyApplePrebuild(dirent: fs.Dirent) {
             "Expected only directory and files in framework",
           );
           if (file.name === "Info.plist") {
-            // TODO: Verify the contents of the Info.plist file
+            const libraryName = path.basename(frameworkDir, ".framework");
+            const infoPlist: unknown = plistModule.default.parse(
+              await fs.promises.readFile(
+                path.join(frameworkDir, file.name),
+                "utf8",
+              ),
+            );
+            assert(
+              typeof infoPlist === "object" && infoPlist !== null,
+              "Expected Info.plist to contain a dictionary",
+            );
+            assert("CFBundleExecutable" in infoPlist);
+            assert("CFBundleIdentifier" in infoPlist);
+            assert.equal(infoPlist.CFBundleExecutable, libraryName);
+            assert.equal(
+              infoPlist.CFBundleIdentifier,
+              `com.callstackincubator.node-api.${libraryName}`.replace(
+                /[^A-Za-z0-9-.]/g,
+                "-",
+              ),
+            );
             continue;
           } else {
             assert(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -281,6 +281,9 @@ importers:
         specifier: workspace:*
         version: link:../host
     devDependencies:
+      '@expo/plist':
+        specifier: 0.4.7
+        version: 0.4.7
       cmake-rn:
         specifier: workspace:*
         version: link:../cmake-rn

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -280,6 +280,9 @@ importers:
       react-native-node-api:
         specifier: workspace:*
         version: link:../host
+      zod:
+        specifier: ^4.1.11
+        version: 4.4.3
     devDependencies:
       '@expo/plist':
         specifier: 0.4.7
@@ -4098,14 +4101,6 @@ packages:
     resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
     engines: {node: '>=12'}
 
-  pify@4.0.1:
-    resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
-    engines: {node: '>=6'}
-
-  pirates@4.0.7:
-    resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
-    engines: {node: '>= 6'}
-
   pkg-dir@8.0.0:
     resolution: {integrity: sha512-4peoBq4Wks0riS0z8741NVv+/8IiTvqnZAr8QGgtdifrtpdXbNw/FxRS1l6NFqm4EMzuS0EDqNNx4XGaz8cuyQ==}
     engines: {node: '>=18'}
@@ -4414,10 +4409,6 @@ packages:
 
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
-
-  slash@3.0.0:
-    resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
-    engines: {node: '>=8'}
 
   slice-ansi@2.1.0:
     resolution: {integrity: sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==}
@@ -6793,7 +6784,9 @@ snapshots:
       metro-runtime: 0.87.0
     transitivePeerDependencies:
       - '@babel/core'
+      - bufferutil
       - supports-color
+      - utf-8-validate
 
   '@react-native/normalize-colors@0.88.0-nightly-20260809-db662caea': {}
 
@@ -8997,10 +8990,6 @@ snapshots:
 
   picomatch@4.0.5: {}
 
-  pify@4.0.1: {}
-
-  pirates@4.0.7: {}
-
   pkg-dir@8.0.0:
     dependencies:
       find-up-simple: 1.0.1
@@ -9380,8 +9369,6 @@ snapshots:
   signal-exit@4.1.0: {}
 
   sisteransi@1.0.5: {}
-
-  slash@3.0.0: {}
 
   slice-ansi@2.1.0:
     dependencies:


### PR DESCRIPTION
## Summary

This builds directly on @wanxiankai's #426 (branch `fix/verify-prebuild-fixtures`, included here as the first commit) with a few refinements on top. It closes #424, superseding #448 and #449 (two independent attempts at the same fix, opened before this one was aware #426 already existed).

> Note: this PR targets `next` in this repo rather than #426's branch directly, because this session's GitHub access is scoped to `callstackincubator/react-native-node-api` only and can't open a PR against a fork. @kraenhansen — happy to have this merged as-is, or closed in favor of #426 if you'd rather land these follow-ups there instead; wanxiankai's original commit is preserved either way.

## What's on top of #426

- **Move the `.js`/`.node` precedence fix into `isNodeApiModule`** (`packages/host/src/node/path-utils.ts`) instead of guarding the Babel plugin's `require()` rewrite with `createRequire(this.filename).resolve(id)`. Reasons:
  - `isNodeApiModule` is the shared utility (also used by `findNodeAddonForBindings`), so fixing it there benefits every caller instead of only the plugin's `require()` handling.
  - `createRequire(...).resolve()` runs Node's own CommonJS resolution algorithm at Babel-transform time to predict what React Native's Metro bundler will resolve at runtime — but Metro doesn't use Node's resolver (it has its own, with platform extensions, Haste, etc.), so the two can diverge. Checking for a same-named `.js`/`.cjs`/`.mjs`/`.json` sibling file directly is simpler and doesn't depend on that assumption holding.
- **Validate the parsed `Info.plist` with a `zod` schema** instead of ad hoc `"key" in obj` checks on an `unknown` value, matching how the rest of the codebase validates untrusted structured data (`zod` is already a dependency across several packages).
- **Reuse the exported `escapeBundleIdentifier`** (now re-exported from `react-native-node-api`'s `node` entrypoint) instead of re-deriving the bundle-identifier escaping regex inline in `verify-prebuilds.mts`, so the verifier can't silently drift out of sync with what `writeFrameworkInfoPlist` actually writes.

## Test plan

- `pnpm install && pnpm run build` — clean
- `pnpm --filter react-native-node-api test` — the `plugin`, `isNodeApiModule`, and `escapeBundleIdentifier` suites pass; the only failures are 4 pre-existing permission-based tests that fail identically with and without this diff (confirmed via `git stash`) because this sandbox runs as root
- `pnpm exec tsc --build packages/node-addon-examples/tsconfig.node-scripts.json` — clean (type-checks `verify-prebuilds.mts`)
- `pnpm exec eslint` on all changed files — clean
- `pnpm run prettier:check` — clean

Closes #424

cc @kraenhansen for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q1k6UQJPPaqKEKmnsRUatt)_