### PR TITLE
Log original package resolution errors

### DIFF
--- a/.changeset/log-package-resolution-errors.md
+++ b/.changeset/log-package-resolution-errors.md
@@ -1,0 +1,5 @@
+---
+"react-native-node-api": patch
+---
+
+Log the original package resolution error during dependency scanning so invalid package entry points include the missing path.

--- a/packages/host/src/node/path-utils.test.ts
+++ b/packages/host/src/node/path-utils.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import path from "node:path";
 import fs from "node:fs";
+import { createRequire } from "node:module";
 import fswin from "fswin";
 
 import {
@@ -9,6 +10,7 @@ import {
   findNodeApiModulePaths,
   findNodeAddonForBindings,
   findPackageDependencyPaths,
+  resolvePackageRoot,
   getLibraryName,
   isNodeApiModule,
   stripExtension,
@@ -352,6 +354,34 @@ describe("findPackageDependencyPaths", () => {
       "lib-a": path.join(tempDir, "node_modules/lib-a"),
       "lib-b": path.join(tempDir, "test-package/node_modules/lib-b"),
     });
+  });
+});
+
+describe("resolvePackageRoot", () => {
+  it("logs the original package resolution error", (context) => {
+    const tempDir = setupTempDirectory(context, {
+      "node_modules/broken-package/package.json": JSON.stringify({
+        name: "broken-package",
+        main: "missing.js",
+      }),
+    });
+    const requireFromRoot = createRequire(path.join(tempDir, "noop.js"));
+    const debug = context.mock.method(console, "debug", () => {});
+
+    assert.equal(
+      resolvePackageRoot(requireFromRoot, "broken-package"),
+      undefined,
+    );
+    assert.equal(debug.mock.callCount(), 1);
+
+    const call = debug.mock.calls[0];
+    assert(call);
+    assert.equal(call.arguments.length, 1);
+    assert.equal(typeof call.arguments[0], "string");
+    assert.match(
+      String(call.arguments[0]),
+      /Failed to resolve package root for "broken-package": Cannot find module .*broken-package[\\/]missing\.js/,
+    );
   });
 });
 

--- a/packages/host/src/node/path-utils.ts
+++ b/packages/host/src/node/path-utils.ts
@@ -260,8 +260,11 @@ export function resolvePackageRoot(
   try {
     const resolvedPath = requireFromPackageRoot.resolve(packageName);
     return packageDirectorySync({ cwd: resolvedPath });
-  } catch {
-    // TODO: Add a debug log here
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.debug(
+      `Failed to resolve package root for "${packageName}": ${message}`,
+    );
     return undefined;
   }
 }


### PR DESCRIPTION
## Summary

- retain the original resolver message when `resolvePackageRoot` fails
- include the package name and exact invalid/missing entry-point path in debug output
- add a cross-platform regression test using a package whose `main` file is missing
- add a patch changeset for `react-native-node-api`

## Verification

- focused TDD regression: failed before the fix with `0 !== 1`, passes after the fix
- `pnpm run build`
- `pnpm run lint`
- `pnpm run prettier:check`
- `pnpm run depcheck`
- `pnpm run test` — host 62 tests, gyp-to-cmake 30 tests, cmake-rn 16 tests passed
- `git diff --check`

Closes #369.