### PR TITLE
fix: declare Node.js require(esm) engine range

### DIFF
--- a/.changeset/modern-nodes-load.md
+++ b/.changeset/modern-nodes-load.md
@@ -1,0 +1,7 @@
+---
+"react-native-node-api": patch
+---
+
+Declare the Node.js versions that support loading ESM from CommonJS so package
+managers warn before the CLI loads its ESM dependencies on an incompatible
+runtime.

--- a/packages/host/package.json
+++ b/packages/host/package.json
@@ -10,6 +10,9 @@
   },
   "main": "dist/react-native/index.js",
   "type": "commonjs",
+  "engines": {
+    "node": ">=20.19.0 <21 || >=22.12.0"
+  },
   "bin": {
     "react-native-node-api": "./bin/react-native-node-api.mjs"
   },


### PR DESCRIPTION
## Summary

- declare the Node.js versions that can load the package’s ESM CLI dependencies from its CommonJS output
- exclude Node 21 and Node 22.0–22.11, which still throw `ERR_REQUIRE_ESM`
- add a patch changeset for `react-native-node-api`

Closes #110.

## Compatibility evidence

The published host output contains `require("@react-native-node-api/cli-utils")`, while CLI utils is an ESM package. [Node’s module history](https://nodejs.org/api/modules.html#loading-ecmascript-modules-using-require) enables this without a flag in Node 20.19.0 and 22.12.0.

Running the same built `dist/node/cli/program.js` artifact:

- Node 20.18.3: `ERR_REQUIRE_ESM`
- Node 20.19.0: loads
- Node 21.7.3: `ERR_REQUIRE_ESM`
- Node 22.11.0: `ERR_REQUIRE_ESM`
- Node 22.12.0: loads

This yields `>=20.19.0 <21 || >=22.12.0`, while the root Node 24 `devEngines` remains unchanged for contributors.

## Test plan

- `pnpm --filter react-native-node-api test` (61 passed)
- `pnpm run build`
- `pnpm run lint`
- `pnpm run prettier:check`
- `pnpm run publint` (all published packages pass strict validation)
- packed `react-native-node-api@1.1.1` and verified the tarball includes the engine range