### PR TITLE
Add cflags support to gyp-to-cmake

### DIFF
--- a/.changeset/gyp-cflags.md
+++ b/.changeset/gyp-cflags.md
@@ -1,0 +1,7 @@
+---
+"gyp-to-cmake": minor
+---
+
+Translate target-level `cflags` from `binding.gyp` into private CMake compile
+options. The parser now validates that `cflags` is an array of strings, and the
+generated options preserve command expansion and escaped spaces.

--- a/packages/gyp-to-cmake/src/gyp.test.ts
+++ b/packages/gyp-to-cmake/src/gyp.test.ts
@@ -38,4 +38,47 @@ describe("gyp.assertRoot", () => {
     assertBinding(input);
     assert(Array.isArray(input.targets));
   });
+
+  it("should accept target cflags", () => {
+    assert.doesNotThrow(() => {
+      assertBinding(
+        {
+          targets: [
+            {
+              target_name: "addon",
+              sources: ["addon.cc"],
+              cflags: ["-fPIC", "-Wall"],
+            },
+          ],
+        },
+        true,
+      );
+    });
+  });
+
+  it("should reject malformed target cflags", () => {
+    assert.throws(() => {
+      assertBinding({
+        targets: [
+          {
+            target_name: "addon",
+            sources: ["addon.cc"],
+            cflags: "-fPIC",
+          },
+        ],
+      });
+    }, /Expected 'cflags' to be an array/);
+
+    assert.throws(() => {
+      assertBinding({
+        targets: [
+          {
+            target_name: "addon",
+            sources: ["addon.cc"],
+            cflags: ["-fPIC", 42],
+          },
+        ],
+      });
+    }, /Expected all cflags to be strings/);
+  });
 });

--- a/packages/gyp-to-cmake/src/gyp.ts
+++ b/packages/gyp-to-cmake/src/gyp.ts
@@ -8,6 +8,7 @@ export type GypTarget = {
   sources: string[];
   include_dirs?: string[];
   defines?: string[];
+  cflags?: string[];
 };
 
 export type GypBinding = {
@@ -49,8 +50,21 @@ export function assertTarget(
       "Expected all include_dirs to be strings",
     );
   }
+  if ("cflags" in target) {
+    const { cflags } = target;
+    assert(Array.isArray(cflags), "Expected 'cflags' to be an array");
+    assert(
+      cflags.every((flag) => typeof flag === "string"),
+      "Expected all cflags to be strings",
+    );
+  }
   if (disallowUnknownProperties) {
-    assertNoExtraProperties(target, ["target_name", "sources", "include_dirs"]);
+    assertNoExtraProperties(target, [
+      "target_name",
+      "sources",
+      "include_dirs",
+      "cflags",
+    ]);
   }
 }
 

--- a/packages/gyp-to-cmake/src/transformer.test.ts
+++ b/packages/gyp-to-cmake/src/transformer.test.ts
@@ -126,6 +126,50 @@ describe("bindingGypToCmakeLists", () => {
     });
   });
 
+  describe("cflags", () => {
+    it("should add cflags as target-specific compile options", () => {
+      const output = bindingGypToCmakeLists({
+        projectName: "some-project",
+        gyp: {
+          targets: [
+            {
+              target_name: "foo",
+              sources: ["foo.cc"],
+              cflags: ["-fPIC", "-Wall", "-DNAME=value with space"],
+            },
+          ],
+        },
+      });
+
+      assert(
+        output.includes(
+          "target_compile_options(foo PRIVATE -fPIC -Wall -DNAME=value\\ with\\ space)",
+        ),
+        `Expected output to include target_compile_options:\n${output}`,
+      );
+    });
+
+    it("should expand cflags command output into compile options", () => {
+      const output = bindingGypToCmakeLists({
+        projectName: "some-project",
+        gyp: {
+          targets: [
+            {
+              target_name: "foo",
+              sources: ["foo.cc"],
+              cflags: ["<!@echo -fPIC -Wall"],
+            },
+          ],
+        },
+      });
+
+      assert(
+        output.includes("target_compile_options(foo PRIVATE -fPIC -Wall)"),
+        `Expected expanded cflags in target_compile_options:\n${output}`,
+      );
+    });
+  });
+
   describe("namespaced targets", () => {
     const gyp = {
       targets: [{ target_name: "addon", sources: ["addon.cc"] }],
@@ -174,6 +218,7 @@ describe("bindingGypToCmakeLists", () => {
               sources: ["addon.cc"],
               include_dirs: ["include"],
               defines: ["FOO"],
+              cflags: ["-fPIC"],
             },
           ],
         },
@@ -186,6 +231,7 @@ describe("bindingGypToCmakeLists", () => {
         "target_link_libraries(some-project-addon PRIVATE weak-node-api)",
         "target_include_directories(some-project-addon PRIVATE include)",
         "target_compile_definitions(some-project-addon PRIVATE FOO)",
+        "target_compile_options(some-project-addon PRIVATE -fPIC)",
         "target_compile_features(some-project-addon PRIVATE cxx_std_17)",
       ]) {
         assert(

--- a/packages/gyp-to-cmake/src/transformer.ts
+++ b/packages/gyp-to-cmake/src/transformer.ts
@@ -95,10 +95,9 @@ export function bindingGypToCmakeLists({
   }
 
   for (const target of gyp.targets) {
-    const { target_name: targetName, defines = [] } = target;
+    const { target_name: targetName, defines = [], cflags = [] } = target;
 
     // TODO: Handle "conditions"
-    // TODO: Handle "cflags"
     // TODO: Handle "ldflags"
 
     const escapedSources = target.sources
@@ -115,6 +114,8 @@ export function bindingGypToCmakeLists({
       .flatMap(mapExpansion)
       .map(transformPath)
       .map(escapeSpaces);
+
+    const escapedCflags = cflags.flatMap(mapExpansion).map(escapeSpaces);
 
     const libraries = [];
     if (weakNodeApi) {
@@ -213,6 +214,12 @@ export function bindingGypToCmakeLists({
     if (escapedDefines.length > 0) {
       lines.push(
         `target_compile_definitions(${actualTargetName} PRIVATE ${escapedDefines.join(" ")})`,
+      );
+    }
+
+    if (escapedCflags.length > 0) {
+      lines.push(
+        `target_compile_options(${actualTargetName} PRIVATE ${escapedCflags.join(" ")})`,
       );
     }
 


### PR DESCRIPTION
Fixes #99

## Summary

- accept and validate target-level `cflags` in parsed `binding.gyp` input
- generate `target_compile_options(<target> PRIVATE ...)` for those flags
- preserve the transformer's existing command-expansion and space-escaping behavior
- target the resolved CMake name when namespaced targets are enabled
- add a minor changeset for `gyp-to-cmake`

This intentionally leaves `cflags_cc`, `ldflags`, variables, conditions, and `target_defaults` to their separate tracked issues.

## TDD evidence

Parser tests first failed because valid `cflags` were rejected as an extra property and malformed values were accepted. After adding the parser boundary, transformer tests failed because no `target_compile_options` command was emitted. Both stages are now green.

Coverage includes:

- valid and malformed `cflags` input
- non-string array entries
- multiple flags and escaped spaces
- command expansion into a flag list
- namespaced target output

## Validation

Node 24.16.0 / pnpm 10.33.0:

- `pnpm --filter gyp-to-cmake test` — 38/38 passed
- `pnpm run build` — passed
- `pnpm test` — 115/115 passed across gyp-to-cmake, host, and cmake-rn
- `pnpm lint` — passed
- `pnpm prettier:check` — passed
- `pnpm depcheck` — passed
- `git diff --check` — passed