### PR TITLE
Verify prebuild metadata and JS addon precedence

### DIFF
--- a/.changeset/tidy-addon-precedence.md
+++ b/.changeset/tidy-addon-precedence.md
@@ -1,0 +1,5 @@
+---
+"react-native-node-api": patch
+---
+
+Preserve JavaScript file resolution when an extensionless require has a sibling Node-API addon.

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "publint": "node scripts/run-in-published.ts pnpm exec publint --strict",
     "prettier:check": "prettier --experimental-cli --check .",
     "prettier:write": "prettier --experimental-cli --write .",
-    "test": "pnpm --filter react-native-node-api --filter cmake-rn --filter gyp-to-cmake run test",
+    "test": "pnpm --filter react-native-node-api --filter cmake-rn --filter gyp-to-cmake run test && pnpm --filter @react-native-node-api/node-addon-examples run test:verify",
     "bootstrap": "node --run build && pnpm --recursive run bootstrap",
     "changeset": "changeset",
     "release": "node --run prerelease && changeset publish",

--- a/packages/host/src/node/babel-plugin/plugin.test.ts
+++ b/packages/host/src/node/babel-plugin/plugin.test.ts
@@ -129,8 +129,8 @@ describe("plugin", () => {
     itTransforms("and does not touch required JS files", {
       files: {
         "package.json": `{ "name": "my-package" }`,
-        // TODO: Add a ./my-addon.node to make this test complete
         "my-addon.js": "// Some JS file",
+        "my-addon.node": "// This is supposed to be a binary file",
         "index.js": `
           const addon = require('./my-addon');
           console.log(addon);

--- a/packages/host/src/node/babel-plugin/plugin.ts
+++ b/packages/host/src/node/babel-plugin/plugin.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { createRequire } from "node:module";
 import path from "node:path";
 
 import type { PluginObj, NodePath } from "@babel/core";
@@ -66,6 +67,14 @@ export function replaceWithRequireNodeAddon(
   );
 }
 
+function resolvesToNonAddon(id: string, filename: string): boolean {
+  try {
+    return !createRequire(path.resolve(filename)).resolve(id).endsWith(".node");
+  } catch {
+    return false;
+  }
+}
+
 export function plugin(): PluginObj {
   return {
     visitor: {
@@ -101,7 +110,8 @@ export function plugin(): PluginObj {
             }
           } else if (
             !path.isAbsolute(id) &&
-            isNodeApiModule(path.join(from, id))
+            isNodeApiModule(path.join(from, id)) &&
+            !resolvesToNonAddon(id, this.filename)
           ) {
             const relativePath = path.join(from, id);
             replaceWithRequireNodeAddon(p, relativePath, {

--- a/packages/node-addon-examples/package.json
+++ b/packages/node-addon-examples/package.json
@@ -24,11 +24,13 @@
     "gyp-to-cmake": "gyp-to-cmake --weak-node-api .",
     "build": "tsx scripts/build-examples.mts",
     "copy-and-build": "node --run copy-examples && node --run gyp-to-cmake && node --run build",
+    "test:verify": "tsx --test scripts/verify-prebuilds.test.mts",
     "verify": "tsx scripts/verify-prebuilds.mts",
     "test": "node --run copy-and-build && node --run verify",
     "bootstrap": "node --run copy-and-build"
   },
   "devDependencies": {
+    "@expo/plist": "0.4.7",
     "cmake-rn": "workspace:*",
     "node-addon-examples": "github:nodejs/node-addon-examples#4b7dd86a85644610e6de80154df9acac9329b509",
     "gyp-to-cmake": "workspace:*",

--- a/packages/node-addon-examples/scripts/verify-prebuilds.mts
+++ b/packages/node-addon-examples/scripts/verify-prebuilds.mts
@@ -1,6 +1,9 @@
 import fs from "node:fs";
 import assert from "node:assert/strict";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+import { parse } from "@expo/plist/build/parse.js";
 
 import { EXAMPLES_DIR } from "./cmake-projects.mjs";
 
@@ -15,6 +18,32 @@ const EXPECTED_XCFRAMEWORK_PLATFORMS = [
   "xros-arm64",
   "xros-arm64-simulator",
 ];
+
+export async function verifyFrameworkInfoPlist(
+  infoPlistPath: string,
+  libraryName: string,
+) {
+  const parsed: unknown = parse(
+    await fs.promises.readFile(infoPlistPath, "utf8"),
+  );
+  assert(
+    typeof parsed === "object" && parsed !== null,
+    `Expected an object in ${infoPlistPath}`,
+  );
+  assert.equal(
+    Reflect.get(parsed, "CFBundleExecutable"),
+    libraryName,
+    `Unexpected CFBundleExecutable in ${infoPlistPath}`,
+  );
+  assert.equal(
+    Reflect.get(parsed, "CFBundleIdentifier"),
+    `com.callstackincubator.node-api.${libraryName}`.replace(
+      /[^A-Za-z0-9-.]/g,
+      "-",
+    ),
+    `Unexpected CFBundleIdentifier in ${infoPlistPath}`,
+  );
+}
 
 async function verifyAndroidPrebuild(dirent: fs.Dirent) {
   console.log(
@@ -65,7 +94,11 @@ async function verifyApplePrebuild(dirent: fs.Dirent) {
             "Expected only directory and files in framework",
           );
           if (file.name === "Info.plist") {
-            // TODO: Verify the contents of the Info.plist file
+            const libraryName = path.basename(frameworkDir, ".framework");
+            await verifyFrameworkInfoPlist(
+              path.join(frameworkDir, file.name),
+              libraryName,
+            );
             continue;
           } else {
             assert(
@@ -82,17 +115,26 @@ async function verifyApplePrebuild(dirent: fs.Dirent) {
   }
 }
 
-for await (const dirent of fs.promises.glob("**/*.*.node", {
-  cwd: EXAMPLES_DIR,
-  withFileTypes: true,
-})) {
-  if (dirent.name.endsWith(".android.node")) {
-    await verifyAndroidPrebuild(dirent);
-  } else if (dirent.name.endsWith(".apple.node")) {
-    await verifyApplePrebuild(dirent);
-  } else {
-    throw new Error(
-      `Unexpected prebuild file: ${dirent.name} in ${dirent.parentPath}`,
-    );
+async function main() {
+  for await (const dirent of fs.promises.glob("**/*.*.node", {
+    cwd: EXAMPLES_DIR,
+    withFileTypes: true,
+  })) {
+    if (dirent.name.endsWith(".android.node")) {
+      await verifyAndroidPrebuild(dirent);
+    } else if (dirent.name.endsWith(".apple.node")) {
+      await verifyApplePrebuild(dirent);
+    } else {
+      throw new Error(
+        `Unexpected prebuild file: ${dirent.name} in ${dirent.parentPath}`,
+      );
+    }
   }
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href
+) {
+  await main();
 }

--- a/packages/node-addon-examples/scripts/verify-prebuilds.test.mts
+++ b/packages/node-addon-examples/scripts/verify-prebuilds.test.mts
@@ -1,0 +1,65 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, it } from "node:test";
+
+import { build } from "@expo/plist/build/build.js";
+
+import { verifyFrameworkInfoPlist } from "./verify-prebuilds.mjs";
+
+async function writeInfoPlist(
+  directory: string,
+  contents: Record<string, unknown>,
+) {
+  const infoPlistPath = path.join(directory, "Info.plist");
+  await fs.promises.writeFile(infoPlistPath, build(contents), "utf8");
+  return infoPlistPath;
+}
+
+describe("verifyFrameworkInfoPlist", () => {
+  it("accepts the expected executable and escaped bundle identifier", async (context) => {
+    const directory = await fs.promises.mkdtemp(
+      path.join(os.tmpdir(), "verify-framework-plist-"),
+    );
+    context.after(() => fs.promises.rm(directory, { recursive: true }));
+    const infoPlistPath = await writeInfoPlist(directory, {
+      CFBundleExecutable: "my_addon",
+      CFBundleIdentifier: "com.callstackincubator.node-api.my-addon",
+    });
+
+    await verifyFrameworkInfoPlist(infoPlistPath, "my_addon");
+  });
+
+  it("rejects an unexpected executable", async (context) => {
+    const directory = await fs.promises.mkdtemp(
+      path.join(os.tmpdir(), "verify-framework-plist-"),
+    );
+    context.after(() => fs.promises.rm(directory, { recursive: true }));
+    const infoPlistPath = await writeInfoPlist(directory, {
+      CFBundleExecutable: "wrong-addon",
+      CFBundleIdentifier: "com.callstackincubator.node-api.my-addon",
+    });
+
+    await assert.rejects(
+      () => verifyFrameworkInfoPlist(infoPlistPath, "my-addon"),
+      /Unexpected CFBundleExecutable/,
+    );
+  });
+
+  it("rejects an unexpected bundle identifier", async (context) => {
+    const directory = await fs.promises.mkdtemp(
+      path.join(os.tmpdir(), "verify-framework-plist-"),
+    );
+    context.after(() => fs.promises.rm(directory, { recursive: true }));
+    const infoPlistPath = await writeInfoPlist(directory, {
+      CFBundleExecutable: "my-addon",
+      CFBundleIdentifier: "com.example.wrong",
+    });
+
+    await assert.rejects(
+      () => verifyFrameworkInfoPlist(infoPlistPath, "my-addon"),
+      /Unexpected CFBundleIdentifier/,
+    );
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -281,6 +281,9 @@ importers:
         specifier: workspace:*
         version: link:../host
     devDependencies:
+      '@expo/plist':
+        specifier: 0.4.7
+        version: 0.4.7
       cmake-rn:
         specifier: workspace:*
         version: link:../cmake-rn


### PR DESCRIPTION
## Summary

- add the missing sibling `.node` fixture to the JS require precedence test
- preserve Node resolution when an extensionless require resolves to JS/JSON before a native addon
- parse every generated framework `Info.plist` and verify `CFBundleExecutable` plus the expected escaped `CFBundleIdentifier`
- add portable plist verifier unit tests to the root test gate
- declare the existing plist parser directly in the package that uses it and add a patch changeset

The completed Babel fixture exposed a real bug: current code transformed `require("./my-addon")` into `requireNodeAddon(...)` even when `my-addon.js` existed. This PR fixes that precedence rather than weakening the new test.

## Verification

- RED: completed Babel fixture failed because it emitted `requireNodeAddon`
- focused Babel plugin suite: 10/10
- focused plist verifier suite: 3/3
- `pnpm run build`
- `pnpm test`: 88 tests passed (62 host, 20 gyp-to-cmake, 3 cmake-rn, 3 plist verifier)
- ESLint on every changed TypeScript file
- `pnpm run prettier:check`
- `pnpm run depcheck`
- `pnpm run publint`
- frozen lockfile validation with Node 24 / pnpm 10.33

Full root lint additionally requires generated native typings from the Rust/clang-format bootstrap; those toolchains are not installed locally. The changed files are lint-clean, and CI runs the documented bootstrap before its root lint job.

Fixes #424