### PR TITLE
ci: bump actions/setup-java from v5 to v6

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -61,7 +61,7 @@ jobs:
       # Set up JDK and Android SDK only because we need weak-node-api, to build ferric-example and to run the linting
       # TODO: Remove this once we have a way to run linting without building the native code
       - name: Set up JDK 17
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v6
         with:
           java-version: "17"
           distribution: "temurin"
@@ -109,7 +109,7 @@ jobs:
         with:
           key: ${{ github.job }}-${{ runner.os }}
       - name: Set up JDK 17
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v6
         with:
           java-version: "17"
           distribution: "temurin"
@@ -280,7 +280,7 @@ jobs:
         with:
           key: ${{ github.job }}-${{ runner.os }}
       - name: Set up JDK 17
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v6
         with:
           java-version: "17"
           distribution: "temurin"
@@ -329,7 +329,7 @@ jobs:
         with:
           key: ${{ github.job }}-${{ runner.os }}
       - name: Set up JDK 17
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v6
         with:
           java-version: "17"
           distribution: "temurin"
@@ -420,7 +420,7 @@ jobs:
         with:
           key: ${{ github.job }}-${{ runner.os }}
       - name: Set up JDK 17
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v6
         with:
           java-version: "17"
           distribution: "temurin"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,7 +115,7 @@ jobs:
         with:
           key: ${{ github.job }}-${{ runner.os }}
       - name: Set up JDK 17
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v6
         with:
           java-version: "17"
           distribution: "temurin"


### PR DESCRIPTION
## Summary

Audited every GitHub Action used across `.github/workflows/check.yml` and `.github/workflows/release.yml` against its latest available release. All actions are pinned to a floating major version tag/branch (`@v7`, `@v6`, `@v4`, `@v2`, `@v1`, etc.) that already tracks the latest release within that major line — except `actions/setup-java`, which was pinned to `@v5` while `@v6` (released 2026-08-24) is now the latest major.

`hendrikmuhs/ccache-action` is intentionally pinned to an exact patch (`v1.2.23`) rather than a floating tag; that pin already documents why (upstream's `v1`/`v1.2` floating tags still point at an older, Node 20-based build) and I re-verified via `git ls-remote` that those floating tags still resolve to a stale commit, so the documented gate has not been unblocked and no change is needed there.

## Change

Bumps all 6 occurrences of `actions/setup-java` (5 in `check.yml`, 1 in `release.yml`) from `@v5` to `@v6`, keeping every usage at the same version.

v6.0.0's breaking changes (removal of legacy Adopt distributions, `jdkFile` → `jdk-file` rename) don't affect our usage, which only passes `java-version: "17"` and `distribution: "temurin"`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01MuTZmA7tDWJmvhmo8UH3yf)_