### PR TITLE
test: enable lambda Node-API examples

### DIFF
--- a/packages/node-addon-examples/scripts/copy-examples.mts
+++ b/packages/node-addon-examples/scripts/copy-examples.mts
@@ -17,11 +17,11 @@ const ALLOW_LIST = [
   "1-getting-started/4_object_factory/node-addon-api/",
   "1-getting-started/5_function_factory/napi/",
   // "1-getting-started/5_function_factory/node-addon-api/",
-  // "1-getting-started/6_object_wrap/napi/", // TODO: Fix C++ support to allow lambda functions
+  "1-getting-started/6_object_wrap/napi/",
   // "1-getting-started/6_object_wrap/node-addon-api/",
-  // "1-getting-started/7_factory_wrap/napi/", // TODO: Fix C++ support to allow lambda functions
+  "1-getting-started/7_factory_wrap/napi/",
   // "1-getting-started/7_factory_wrap/node-addon-api/",
-  // "2-js-to-native-conversion/8_passing_wrapped/napi/", // TODO: Fix C++ support to allow lambda functions
+  "2-js-to-native-conversion/8_passing_wrapped/napi/",
   // "2-js-to-native-conversion/8_passing_wrapped/node-addon-api/",
   // "2-js-to-native-conversion/array_buffer_to_native/node-addon-api/",
   // "2-js-to-native-conversion/object-template-demo/napi/", // TODO: Fix C++ support to allow noexcept

--- a/packages/node-addon-examples/src/index.ts
+++ b/packages/node-addon-examples/src/index.ts
@@ -75,6 +75,20 @@ export const suites: Record<
       assertLogs(() => {
         require("../examples/1-getting-started/5_function_factory/napi/addon.js");
       }, ["hello world"]),
+    "6_object_wrap/napi": () =>
+      assertLogs(() => {
+        require("../examples/1-getting-started/6_object_wrap/napi/addon.js");
+      }, ["11", "12", "13", "13", "130", "-13", "false"]),
+    "7_factory_wrap/napi": () =>
+      assertLogs(() => {
+        require("../examples/1-getting-started/7_factory_wrap/napi/addon.js");
+      }, ["11", "12", "13", "21", "22", "23"]),
+  },
+  "2-js-to-native-conversion": {
+    "8_passing_wrapped/napi": () =>
+      assertLogs(() => {
+        require("../examples/2-js-to-native-conversion/8_passing_wrapped/napi/addon.js");
+      }, ["30"]),
   },
   "5-async-work": {
     async_work_thread_safe_function: () => {


### PR DESCRIPTION
## Summary

- enable the three upstream Node-API examples that were skipped for lambda support
- add each example to the mobile runtime suite with exact output assertions
- remove the stale lambda TODOs; the current `gyp-to-cmake` CLI already emits `cxx_std_17`, so no transformer workaround is needed

This addresses the lambda portion of #423. The independent `noexcept` and output-directory items remain out of scope.

## Verification

- `pnpm run build`
- `pnpm test`
- `pnpm run lint`
- `pnpm run prettier:check`
- Apple: all three examples compiled into universal iOS Simulator XCFrameworks
- Android: all three examples compiled for `arm64-v8a`, `armeabi-v7a`, `x86`, and `x86_64`

## Note

`node-addon-examples verify` expects a release-style Apple build containing both the `ios-arm64` device slice and the simulator slice. The local current-development build produces only the universal simulator slice, so that verifier stops on the pre-existing async-work example before reaching any newly enabled example. Both native platform builds above complete successfully.
