### PR TITLE
ci: bump hendrikmuhs/ccache-action from v1.2.23 to v1.2.24

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -55,7 +55,7 @@ jobs:
         with:
           clang-format: true
       - name: ccache
-        uses: hendrikmuhs/ccache-action@v1.2.23
+        uses: hendrikmuhs/ccache-action@v1.2.24
         with:
           key: ${{ github.job }}-${{ runner.os }}
       # Set up JDK and Android SDK only because we need weak-node-api, to build ferric-example and to run the linting
@@ -105,7 +105,7 @@ jobs:
         with:
           clang-format: true
       - name: ccache
-        uses: hendrikmuhs/ccache-action@v1.2.23
+        uses: hendrikmuhs/ccache-action@v1.2.24
         with:
           key: ${{ github.job }}-${{ runner.os }}
       - name: Set up JDK 17
@@ -145,7 +145,7 @@ jobs:
         with:
           clang-format: true
       - name: ccache
-        uses: hendrikmuhs/ccache-action@v1.2.23
+        uses: hendrikmuhs/ccache-action@v1.2.24
         with:
           key: ${{ github.job }}-${{ runner.os }}
       - run: pnpm install
@@ -188,7 +188,7 @@ jobs:
         with:
           clang-format: true
       - name: ccache
-        uses: hendrikmuhs/ccache-action@v1.2.23
+        uses: hendrikmuhs/ccache-action@v1.2.24
         with:
           key: ${{ github.job }}-${{ runner.os }}
           # The action defaults to 500M, which a from-source React Native build
@@ -276,7 +276,7 @@ jobs:
         with:
           clang-format: true
       - name: ccache
-        uses: hendrikmuhs/ccache-action@v1.2.23
+        uses: hendrikmuhs/ccache-action@v1.2.24
         with:
           key: ${{ github.job }}-${{ runner.os }}
       - name: Set up JDK 17
@@ -325,7 +325,7 @@ jobs:
         with:
           clang-format: true
       - name: ccache
-        uses: hendrikmuhs/ccache-action@v1.2.23
+        uses: hendrikmuhs/ccache-action@v1.2.24
         with:
           key: ${{ github.job }}-${{ runner.os }}
       - name: Set up JDK 17
@@ -416,7 +416,7 @@ jobs:
         with:
           clang-format: true
       - name: ccache
-        uses: hendrikmuhs/ccache-action@v1.2.23
+        uses: hendrikmuhs/ccache-action@v1.2.24
         with:
           key: ${{ github.job }}-${{ runner.os }}
       - name: Set up JDK 17

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,7 +111,7 @@ jobs:
         with:
           clang-format: true
       - name: ccache
-        uses: hendrikmuhs/ccache-action@v1.2.23
+        uses: hendrikmuhs/ccache-action@v1.2.24
         with:
           key: ${{ github.job }}-${{ runner.os }}
       - name: Set up JDK 17


### PR DESCRIPTION
## Summary

Scheduled audit of every GitHub Action used across `.github/workflows/check.yml` and `.github/workflows/release.yml` against its latest available release (following up on #456, which handled `actions/setup-java`).

`hendrikmuhs/ccache-action` was pinned to an exact patch, `v1.2.23`, per the comment above its first usage in `check.yml`. That comment documents why an exact pin is used instead of the floating `v1`/`v1.2` tags (they still resolve to a Node.js 20-based build) and says to float again once upstream moves them to `>= v1.2.22`. I confirmed via each tag's `action.yml` that:

- `v1` and `v1.2` (floating) still declare `using: "node20"` — the gate has **not** been unblocked, so the documented reason still holds and the exact-pin approach stays.
- `v1.2.24` (published after `v1.2.23`, and after this pin was last verified) declares `using: "node24"`, same as `v1.2.23`.

So the only actionable gap is that `v1.2.24` is now the latest exact tag and `v1.2.23` isn't, with no reason to stay behind.

## Change

Bumps all 8 occurrences of `hendrikmuhs/ccache-action` (7 in `check.yml`, 1 in `release.yml`) from `@v1.2.23` to `@v1.2.24`, keeping every usage at the same version. No comment changes — the existing rationale for the exact pin is still accurate.

Every other action in these workflows (`actions/checkout@v7`, `actions/setup-node@v7`, `pnpm/action-setup@v6`, `aminya/setup-cpp@v1`, `android-actions/setup-android@v4`, `actions/upload-artifact@v7`, `reactivecircus/android-emulator-runner@v2`, `changesets/action/*@v2`) is pinned to a floating major tag that already tracks the latest release in that line — no changes needed there. `actions/setup-java@v5` → `@v6` is already covered by open PR #456.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UkvgWR9HfXtivLqo3ji2zd

---
_Generated by [Claude Code](https://claude.ai/code/session_01UkvgWR9HfXtivLqo3ji2zd)_